### PR TITLE
Refactor offer workflow into dedicated service

### DIFF
--- a/app/Http/Controllers/OfferController.php
+++ b/app/Http/Controllers/OfferController.php
@@ -2,39 +2,26 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\{Assignment, Batch, Channel};
+use App\Models\{Batch, Channel};
+use App\Services\AssignmentService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\{Storage, URL};
-use Illuminate\Support\Str;
 use ZipStream\ZipStream;
 
 class OfferController extends Controller
 {
+    public function __construct(private AssignmentService $assignments)
+    {
+    }
+
     public function show(Request $req, Batch $batch, Channel $channel)
     {
         abort_unless($req->hasValidSignature(), 403);
 
-        $items = Assignment::with('video')
-            ->where('batch_id', $batch->id)
-            ->where('channel_id', $channel->id)
-            ->whereIn('status', ['queued', 'notified'])
-            ->get();
+        $items = $this->assignments->fetchPending($batch, $channel);
 
-        foreach ($items as $a) {
-            $plain = Str::random(40);
-            $expiry = $a->expires_at ? min($a->expires_at, now()->addDays(6)) : now()->addDays(6);
-
-            if ($a->status === 'queued') {
-                $a->status = 'notified';
-                $a->last_notified_at = now();
-            }
-            $a->download_token = hash('sha256', $plain);
-            $a->expires_at = $expiry;
-            $a->save();
-
-            $a->temp_url = URL::temporarySignedRoute(
-                'assignments.download', $expiry, ['assignment' => $a->id, 't' => $plain]
-            );
+        foreach ($items as $assignment) {
+            $assignment->temp_url = $this->assignments->prepareDownload($assignment);
         }
 
         return view('offer.show', [
@@ -51,17 +38,12 @@ class OfferController extends Controller
     {
         abort_unless($req->hasValidSignature(), 403);
 
-        $items = Assignment::with('video')
-            ->where('batch_id', $batch->id)
-            ->where('channel_id', $channel->id)
-            ->whereIn('status', ['queued', 'notified'])
-            ->get();
+        $items = $this->assignments->fetchPending($batch, $channel);
 
         abort_if($items->isEmpty(), 404);
 
-        // Wichtig: Vor ZipStream KEINE Ausgabe erzeugen!
         $filename = sprintf('videos_%s_%s.zip', $batch->id, \Str::slug($channel->name));
-        $zip = new ZipStream($filename); // v3.2 sendet die nötigen Header selbst
+        $zip = new ZipStream($filename);
 
         foreach ($items as $a) {
             $rel = $a->video->path;
@@ -78,9 +60,8 @@ class OfferController extends Controller
             fclose($stream);
         }
 
-        $zip->finish(); // schließt den Stream + sendet Footer
-        // ZipStream hat bereits alles an den Client geschickt.
-        // Laravel erwartet eine Response – gib "leer" zurück, ohne noch Inhalte zu senden:
+        $zip->finish();
+
         return response()->noContent();
     }
 }

--- a/app/Services/AssignmentService.php
+++ b/app/Services/AssignmentService.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\{Assignment, Batch, Channel};
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Str;
+
+class AssignmentService
+{
+    /**
+     * Retrieve assignments that are ready for offering to a channel.
+     */
+    public function fetchPending(Batch $batch, Channel $channel): Collection
+    {
+        return Assignment::with('video')
+            ->where('batch_id', $batch->id)
+            ->where('channel_id', $channel->id)
+            ->whereIn('status', ['queued', 'notified'])
+            ->get();
+    }
+
+    /**
+     * Prepare an assignment for download and return a temporary URL.
+     */
+    public function prepareDownload(Assignment $assignment): string
+    {
+        $plain = Str::random(40);
+        $expiry = $assignment->expires_at
+            ? min($assignment->expires_at, now()->addDays(6))
+            : now()->addDays(6);
+
+        if ($assignment->status === 'queued') {
+            $assignment->status = 'notified';
+            $assignment->last_notified_at = now();
+        }
+
+        $assignment->download_token = hash('sha256', $plain);
+        $assignment->expires_at = $expiry;
+        $assignment->save();
+
+        return URL::temporarySignedRoute(
+            'assignments.download',
+            $expiry,
+            ['assignment' => $assignment->id, 't' => $plain]
+        );
+    }
+}
+


### PR DESCRIPTION
## Summary
- extract assignment offer preparation into `AssignmentService`
- simplify `OfferController` using new service

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6895d06c89dc8329993ac4176bdad5f7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced improved handling for assignment downloads, providing secure temporary download links with expiration.
* **Refactor**
  * Enhanced performance and maintainability by restructuring assignment-related logic into a dedicated service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->