### PR TITLE
Refactor console commands into services

### DIFF
--- a/app/Console/Commands/AssignDistribute.php
+++ b/app/Console/Commands/AssignDistribute.php
@@ -4,102 +4,29 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
-use App\Models\{Assignment, Batch, Channel, ChannelVideoBlock, Video};
+use App\Services\AssignmentDistributor;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\DB;
+use RuntimeException;
 
 class AssignDistribute extends Command
 {
     protected $signature = 'assign:distribute {--quota=}';
     protected $description = 'Verteilt neue und expired Videos fair auf Kanäle (Round-Robin, gewichtet, Quota/Woche).';
 
+    public function __construct(private AssignmentDistributor $distributor)
+    {
+        parent::__construct();
+    }
+
     public function handle(): int
     {
-        $batch = Batch::query()->create(['type' => 'assign', 'started_at' => now()]);
-
-        // Neue Videos seit letztem Assign-Finish ermitteln
-        $last = Batch::query()->where('type', 'assign')->whereNotNull('finished_at')->latest()->first();
-        $newVideos = Video::query()->when($last, fn($q) => $q->where('created_at', '>', $last->finished_at))
-            ->orderBy('id')
-            ->get();
-
-        // Expired zurück in den Pool (einmalig pro Video)
-        $expiredVideoIds = Assignment::query()->where('status', 'expired')->pluck('video_id')->unique();
-        $expiredVideos = Video::query()->whereIn('id', $expiredVideoIds)->get();
-
-        $poolVideos = $newVideos->concat($expiredVideos)->unique('id')->values();
-        if ($poolVideos->isEmpty()) {
-            $batch->update(['finished_at' => now(), 'stats' => ['assigned' => 0]]);
-            $this->info('Nichts zu verteilen.');
-            return 0;
+        try {
+            $quota = $this->option('quota');
+            $stats = $this->distributor->distribute($quota !== null ? (int)$quota : null);
+            $this->info("Assigned={$stats['assigned']}, skipped={$stats['skipped']}");
+        } catch (RuntimeException $e) {
+            $this->warn($e->getMessage());
         }
-
-        // Kanal-Pool nach Gewicht
-        $channels = Channel::query()->orderBy('id')->get();
-        if ($channels->isEmpty()) {
-            $this->warn('Keine Kanäle konfiguriert.');
-            return 0;
-        }
-        $pool = collect();
-        foreach ($channels as $c) {
-            $pool = $pool->merge(array_fill(0, max(1, (int)$c->weight), $c));
-        }
-
-        // Quota: optionale CLI-Override, sonst channel->weekly_quota
-        $quota = $channels->mapWithKeys(fn($c) => [$c->id => (int)($this->option('quota') ?: $c->weekly_quota)]);
-
-        $assigned = 0;
-        $skipped = 0;
-        foreach ($poolVideos as $v) {
-            // blockierte Kanäle für dieses Video (Cooldown) ausschließen
-            $blockedChannelIds = ChannelVideoBlock::query()->where('video_id', $v->id)->where('until', '>',
-                now())->pluck('channel_id')->all();
-
-            // Finde den nächsten Kanal mit Rest-Quota, der nicht blockiert ist und noch kein Assignment zu (video,channel) hat
-            $target = null;
-            $rotations = 0;
-            while ($rotations < $pool->count()) {
-                $candidate = $pool->first();
-                $pool->push($pool->shift()); // rotiere
-                $rotations++;
-
-                if ($quota[$candidate->id] <= 0) {
-                    continue;
-                }
-                if (in_array($candidate->id, $blockedChannelIds, true)) {
-                    continue;
-                }
-                $exists = Assignment::query()->where('video_id', $v->id)->where('channel_id', $candidate->id)->exists();
-                if ($exists) {
-                    continue;
-                }
-                $target = $candidate;
-                break;
-            }
-
-            if (!$target) {
-                $skipped++;
-                continue;
-            }
-
-            Assignment::query()->create([
-                'video_id' => $v->id,
-                'channel_id' => $target->id,
-                'batch_id' => $batch->id,
-                'status' => 'queued',
-                'attempts' => DB::raw('attempts'),
-            ]);
-            $quota[$target->id]--;
-            $assigned++;
-
-            // Wenn alle Quotas 0 sind → Abbruch
-            if (collect($quota->all())->every(fn($q) => $q <= 0)) {
-                break;
-            }
-        }
-
-        $batch->update(['finished_at' => now(), 'stats' => ['assigned' => $assigned, 'skipped' => $skipped]]);
-        $this->info("Assigned=$assigned, skipped=$skipped");
         return 0;
     }
 }

--- a/app/Console/Commands/AssignExpire.php
+++ b/app/Console/Commands/AssignExpire.php
@@ -2,7 +2,7 @@
 // app/Console/Commands/AssignExpire.php
 namespace App\Console\Commands;
 
-use App\Models\{Assignment, Batch, ChannelVideoBlock};
+use App\Services\AssignmentExpirer;
 use Illuminate\Console\Command;
 
 class AssignExpire extends Command
@@ -10,28 +10,15 @@ class AssignExpire extends Command
     protected $signature = 'assign:expire {--cooldown-days=14}';
     protected $description = 'Markiert überfällige Assignments als expired und setzt Cooldown je (channel, video).';
 
+    public function __construct(private AssignmentExpirer $expirer)
+    {
+        parent::__construct();
+    }
+
     public function handle(): int
     {
         $cooldownDays = (int)$this->option('cooldown-days');
-        $batch = Batch::query()->create([
-            'type' => 'assign',
-            'started_at' => now()
-        ]); // protokolliere als Teil eines Assign-Zyklus
-        $cnt = 0;
-
-        Assignment::query()->where('status', 'notified')
-            ->where('expires_at', '<', now())
-            ->chunkById(500, function ($items) use (&$cnt, $cooldownDays) {
-                foreach ($items as $a) {
-                    $a->update(['status' => 'expired']);
-                    ChannelVideoBlock::query()->updateOrCreate(
-                        ['channel_id' => $a->channel_id, 'video_id' => $a->video_id],
-                        ['until' => now()->addDays($cooldownDays)]
-                    );
-                    $cnt++;
-                }
-            });
-        $batch->update(['finished_at' => now(), 'stats' => ['expired' => $cnt]]);
+        $cnt = $this->expirer->expire($cooldownDays);
         $this->info("Expired: $cnt");
         return 0;
     }

--- a/app/Console/Commands/IngestScan.php
+++ b/app/Console/Commands/IngestScan.php
@@ -2,57 +2,31 @@
 // app/Console/Commands/IngestScan.php
 namespace App\Console\Commands;
 
-use App\Models\{Batch, Video};
+use App\Services\IngestScanner;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Storage;
+use RuntimeException;
 
 class IngestScan extends Command
 {
     protected $signature = 'ingest:scan {--inbox=/srv/ingest/inbox}';
     protected $description = 'Scannt Inbox, dedupe per SHA-256, verschiebt content-addressiert in storage.';
 
+    public function __construct(private IngestScanner $scanner)
+    {
+        parent::__construct();
+    }
+
     public function handle(): int
     {
         $inbox = $this->option('inbox');
-        $batch = Batch::query()->create(['type' => 'ingest', 'started_at' => now()]);
-        if (!is_dir($inbox)) {
-            $this->error("Inbox $inbox fehlt");
+
+        try {
+            $stats = $this->scanner->scan($inbox);
+            $this->info("Ingest done. new={$stats['new']} dups={$stats['dups']}");
+            return 0;
+        } catch (RuntimeException $e) {
+            $this->error($e->getMessage());
             return 1;
         }
-
-        $cntNew = $cntDup = 0;
-        foreach (glob($inbox.'/*') as $src) {
-            if (!is_file($src)) {
-                continue;
-            }
-            try {
-                $hash = hash_file('sha256', $src);
-                $ext = strtolower(pathinfo($src, PATHINFO_EXTENSION));
-                if (Video::query()->where('hash', $hash)->exists()) {
-                    unlink($src);
-                    $cntDup++;
-                    continue;
-                }
-
-                $sub = substr($hash, 0, 2).'/'.substr($hash, 2, 2);
-                $dstRel = "videos/$sub/$hash".($ext ? ".$ext" : "");
-                Storage::makeDirectory("videos/$sub");
-                rename($src, Storage::path($dstRel));
-
-                Video::query()->create([
-                    'hash' => $hash,
-                    'ext' => $ext,
-                    'bytes' => filesize(Storage::path($dstRel)),
-                    'path' => $dstRel,
-                    'meta' => null,
-                ]);
-                $cntNew++;
-            } catch (\Throwable $e) {
-                $this->error($e->getMessage());
-            }
-        }
-        $batch->update(['finished_at' => now(), 'stats' => ['new' => $cntNew, 'dups' => $cntDup]]);
-        $this->info("Ingest done. new=$cntNew dups=$cntDup");
-        return 0;
     }
 }

--- a/app/Console/Commands/NotifyChannels.php
+++ b/app/Console/Commands/NotifyChannels.php
@@ -4,60 +4,23 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
-use App\Mail\ChannelAssignmentMail;
-use App\Models\{Assignment, Batch};
+use App\Services\ChannelNotifier;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Mail;
-use Illuminate\Support\Facades\URL;
-use Illuminate\Support\Str;
 
 class NotifyChannels extends Command
 {
     protected $signature = 'notify:channels {--ttl-hours=144}'; // 6 Tage
     protected $description = 'Sendet Mails pro Kanal mit signierten Download-Links für neue Assignments.';
 
+    public function __construct(private ChannelNotifier $notifier)
+    {
+        parent::__construct();
+    }
+
     public function handle(): int
     {
         $ttl = (int)$this->option('ttl-hours');
-        $batch = Batch::query()->create(['type' => 'notify', 'started_at' => now()]);
-
-        $groups = Assignment::query()->where('status', 'queued')
-            ->with(['channel', 'video'])
-            ->get()
-            ->groupBy('channel_id');
-
-        $sent = 0;
-        foreach ($groups as $channelId => $items) {
-            $links = [];
-            foreach ($items as $a) {
-                $plain = Str::random(40);
-                $a->download_token = hash('sha256', $plain);
-                $a->expires_at = now()->addHours($ttl);
-                $a->last_notified_at = now();
-
-                $url = URL::temporarySignedRoute(
-                    'assignments.download',
-                    $a->expires_at,
-                    ['assignment' => $a->id, 't' => $plain]
-                );
-                $links[] = [
-                    'id' => $a->id,
-                    'hash' => $a->video->hash,
-                    'bytes' => $a->video->bytes,
-                    'ext' => $a->video->ext,
-                    'url' => $url,
-                ];
-                $a->status = 'notified';
-                $a->attempts++;
-                $a->save();
-            }
-
-            $mailable = new ChannelAssignmentMail($items->first()->channel, $links);
-            Mail::to($items->first()->channel->email)->queue($mailable);
-            $sent++;
-        }
-
-        $batch->update(['finished_at' => now(), 'stats' => ['emails' => $sent]]);
+        $sent = $this->notifier->notify($ttl);
         $this->info("Emails queued for $sent channels");
         return 0;
     }

--- a/app/Console/Commands/NotifyOffers.php
+++ b/app/Console/Commands/NotifyOffers.php
@@ -2,58 +2,34 @@
 
 namespace App\Console\Commands;
 
-use App\Mail\NewOfferMail;
-use App\Models\{Assignment, Batch, Channel};
+use App\Services\OfferNotifier;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\{Mail, URL};
+use RuntimeException;
 
 class NotifyOffers extends Command
 {
     protected $signature = 'notify:offers {--ttl-days=6}';
     protected $description = 'Sendet je Kanal einen Offer-Link (Übersicht + ZIP).';
 
+    public function __construct(private OfferNotifier $notifier)
+    {
+        parent::__construct();
+    }
+
     public function handle(): int
     {
         $ttlDays = (int)$this->option('ttl-days');
 
-        $assignBatch = Batch::query()->where('type', 'assign')->whereNotNull('finished_at')
-            ->latest('id')->first();
-
-        if (!$assignBatch) {
-            $this->warn('Kein Assign-Batch gefunden.');
-            return 0;
+        try {
+            $result = $this->notifier->notify($ttlDays);
+            if ($result['sent'] === 0) {
+                $this->info('Keine Kanäle mit neuen Angeboten.');
+            } else {
+                $this->info("Offer emails queued: {$result['sent']} (Assign-Batch #{$result['batchId']})");
+            }
+        } catch (RuntimeException $e) {
+            $this->warn($e->getMessage());
         }
-
-        $channelIds = Assignment::query()->where('batch_id', $assignBatch->id)
-            ->whereIn('status', ['queued', 'notified'])
-            ->pluck('channel_id')->unique()->values();
-
-        if ($channelIds->isEmpty()) {
-            $this->info('Keine Kanäle mit neuen Angeboten.');
-            return 0;
-        }
-
-        $sent = 0;
-        foreach (Channel::query()->whereIn('id', $channelIds)->get() as $channel) {
-            $offerUrl = URL::temporarySignedRoute(
-                'offer.show',
-                now()->addDays($ttlDays),
-                ['batch' => $assignBatch->id, 'channel' => $channel->id]
-            );
-
-            Mail::to($channel->email)->queue(
-                new NewOfferMail($assignBatch, $channel, $offerUrl, now()->addDays($ttlDays))
-            );
-            $sent++;
-        }
-
-        $notifyBatch = Batch::query()->create([
-            'type' => 'notify',
-            'started_at' => now(),
-            'finished_at' => now(),
-            'stats' => ['emails' => $sent]
-        ]);
-        $this->info("Offer emails queued: $sent (Assign-Batch #{$assignBatch->id})");
         return 0;
     }
 }

--- a/app/Services/AssignmentDistributor.php
+++ b/app/Services/AssignmentDistributor.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\{Assignment, Batch, Channel, ChannelVideoBlock, Video};
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+
+class AssignmentDistributor
+{
+    /**
+     * Distribute new and expired videos across channels.
+     *
+     * @param int|null $quotaOverride optional quota per channel
+     * @return array{assigned:int, skipped:int}
+     */
+    public function distribute(?int $quotaOverride = null): array
+    {
+        $batch = Batch::query()->create(['type' => 'assign', 'started_at' => now()]);
+
+        $last = Batch::query()->where('type', 'assign')->whereNotNull('finished_at')->latest()->first();
+        $newVideos = Video::query()->when($last, fn($q) => $q->where('created_at', '>', $last->finished_at))
+            ->orderBy('id')
+            ->get();
+
+        $expiredVideoIds = Assignment::query()->where('status', 'expired')->pluck('video_id')->unique();
+        $expiredVideos = Video::query()->whereIn('id', $expiredVideoIds)->get();
+
+        $poolVideos = $newVideos->concat($expiredVideos)->unique('id')->values();
+        if ($poolVideos->isEmpty()) {
+            $batch->update(['finished_at' => now(), 'stats' => ['assigned' => 0]]);
+            throw new RuntimeException('Nichts zu verteilen.');
+        }
+
+        $channels = Channel::query()->orderBy('id')->get();
+        if ($channels->isEmpty()) {
+            $batch->update(['finished_at' => now(), 'stats' => ['assigned' => 0]]);
+            throw new RuntimeException('Keine Kanäle konfiguriert.');
+        }
+        $pool = collect();
+        foreach ($channels as $c) {
+            $pool = $pool->merge(array_fill(0, max(1, (int)$c->weight), $c));
+        }
+
+        $quota = $channels->mapWithKeys(fn($c) => [$c->id => (int)($quotaOverride ?: $c->weekly_quota)]);
+
+        $assigned = 0;
+        $skipped = 0;
+        foreach ($poolVideos as $v) {
+            $blockedChannelIds = ChannelVideoBlock::query()->where('video_id', $v->id)
+                ->where('until', '>', now())
+                ->pluck('channel_id')->all();
+
+            $target = null;
+            $rotations = 0;
+            while ($rotations < $pool->count()) {
+                $candidate = $pool->first();
+                $pool->push($pool->shift());
+                $rotations++;
+
+                if ($quota[$candidate->id] <= 0) {
+                    continue;
+                }
+                if (in_array($candidate->id, $blockedChannelIds, true)) {
+                    continue;
+                }
+                $exists = Assignment::query()->where('video_id', $v->id)
+                    ->where('channel_id', $candidate->id)
+                    ->exists();
+                if ($exists) {
+                    continue;
+                }
+                $target = $candidate;
+                break;
+            }
+
+            if (!$target) {
+                $skipped++;
+                continue;
+            }
+
+            Assignment::query()->create([
+                'video_id' => $v->id,
+                'channel_id' => $target->id,
+                'batch_id' => $batch->id,
+                'status' => 'queued',
+                'attempts' => DB::raw('attempts'),
+            ]);
+            $quota[$target->id]--;
+            $assigned++;
+
+            if (collect($quota->all())->every(fn($q) => $q <= 0)) {
+                break;
+            }
+        }
+
+        $batch->update(['finished_at' => now(), 'stats' => ['assigned' => $assigned, 'skipped' => $skipped]]);
+        return ['assigned' => $assigned, 'skipped' => $skipped];
+    }
+}
+

--- a/app/Services/AssignmentExpirer.php
+++ b/app/Services/AssignmentExpirer.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\{Assignment, Batch, ChannelVideoBlock};
+
+class AssignmentExpirer
+{
+    /**
+     * Expire assignments that have passed their TTL and apply cooldown blocks.
+     */
+    public function expire(int $cooldownDays): int
+    {
+        $batch = Batch::query()->create(['type' => 'assign', 'started_at' => now()]);
+        $cnt = 0;
+
+        Assignment::query()->where('status', 'notified')
+            ->where('expires_at', '<', now())
+            ->chunkById(500, function ($items) use (&$cnt, $cooldownDays) {
+                foreach ($items as $a) {
+                    $a->update(['status' => 'expired']);
+                    ChannelVideoBlock::query()->updateOrCreate(
+                        ['channel_id' => $a->channel_id, 'video_id' => $a->video_id],
+                        ['until' => now()->addDays($cooldownDays)]
+                    );
+                    $cnt++;
+                }
+            });
+
+        $batch->update(['finished_at' => now(), 'stats' => ['expired' => $cnt]]);
+        return $cnt;
+    }
+}
+

--- a/app/Services/AssignmentService.php
+++ b/app/Services/AssignmentService.php
@@ -24,12 +24,12 @@ class AssignmentService
     /**
      * Prepare an assignment for download and return a temporary URL.
      */
-    public function prepareDownload(Assignment $assignment): string
+    public function prepareDownload(Assignment $assignment, int $ttlHours = 144): string
     {
         $plain = Str::random(40);
         $expiry = $assignment->expires_at
-            ? min($assignment->expires_at, now()->addDays(6))
-            : now()->addDays(6);
+            ? min($assignment->expires_at, now()->addHours($ttlHours))
+            : now()->addHours($ttlHours);
 
         if ($assignment->status === 'queued') {
             $assignment->status = 'notified';

--- a/app/Services/ChannelNotifier.php
+++ b/app/Services/ChannelNotifier.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Mail\ChannelAssignmentMail;
+use App\Models\{Assignment, Batch};
+use Illuminate\Support\Facades\Mail;
+
+class ChannelNotifier
+{
+    public function __construct(private AssignmentService $assignmentService)
+    {
+    }
+
+    /**
+     * Notify channels about pending assignments.
+     */
+    public function notify(int $ttlHours): int
+    {
+        $batch = Batch::query()->create(['type' => 'notify', 'started_at' => now()]);
+
+        $groups = Assignment::query()->where('status', 'queued')
+            ->with(['channel', 'video'])
+            ->get()
+            ->groupBy('channel_id');
+
+        $sent = 0;
+        foreach ($groups as $items) {
+            $links = [];
+            foreach ($items as $a) {
+                $url = $this->assignmentService->prepareDownload($a, $ttlHours);
+                $links[] = [
+                    'id' => $a->id,
+                    'hash' => $a->video->hash,
+                    'bytes' => $a->video->bytes,
+                    'ext' => $a->video->ext,
+                    'url' => $url,
+                ];
+            }
+            Mail::to($items->first()->channel->email)->queue(
+                new ChannelAssignmentMail($items->first()->channel, $links)
+            );
+            $sent++;
+        }
+
+        $batch->update(['finished_at' => now(), 'stats' => ['emails' => $sent]]);
+        return $sent;
+    }
+}
+

--- a/app/Services/IngestScanner.php
+++ b/app/Services/IngestScanner.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\{Batch, Video};
+use Illuminate\Support\Facades\{Log, Storage};
+use RuntimeException;
+
+class IngestScanner
+{
+    /**
+     * Scan an inbox for new videos, deduplicate and move them to storage.
+     *
+     * @return array{new:int, dups:int}
+     */
+    public function scan(string $inbox): array
+    {
+        $batch = Batch::query()->create(['type' => 'ingest', 'started_at' => now()]);
+        if (!is_dir($inbox)) {
+            $batch->update(['finished_at' => now(), 'stats' => ['new' => 0, 'dups' => 0]]);
+            throw new RuntimeException("Inbox $inbox fehlt");
+        }
+
+        $cntNew = $cntDup = 0;
+        foreach (glob($inbox.'/*') as $src) {
+            if (!is_file($src)) {
+                continue;
+            }
+            try {
+                $hash = hash_file('sha256', $src);
+                $ext = strtolower(pathinfo($src, PATHINFO_EXTENSION));
+                if (Video::query()->where('hash', $hash)->exists()) {
+                    unlink($src);
+                    $cntDup++;
+                    continue;
+                }
+
+                $sub = substr($hash, 0, 2).'/'.substr($hash, 2, 2);
+                $dstRel = "videos/$sub/$hash".($ext ? ".$ext" : "");
+                Storage::makeDirectory("videos/$sub");
+                rename($src, Storage::path($dstRel));
+
+                Video::query()->create([
+                    'hash' => $hash,
+                    'ext' => $ext,
+                    'bytes' => filesize(Storage::path($dstRel)),
+                    'path' => $dstRel,
+                    'meta' => null,
+                ]);
+                $cntNew++;
+            } catch (\Throwable $e) {
+                Log::error($e->getMessage());
+            }
+        }
+        $batch->update(['finished_at' => now(), 'stats' => ['new' => $cntNew, 'dups' => $cntDup]]);
+        return ['new' => $cntNew, 'dups' => $cntDup];
+    }
+}
+

--- a/app/Services/OfferNotifier.php
+++ b/app/Services/OfferNotifier.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Mail\NewOfferMail;
+use App\Models\{Assignment, Batch, Channel};
+use Illuminate\Support\Facades\{Mail, URL};
+use RuntimeException;
+
+class OfferNotifier
+{
+    /**
+     * Notify channels about new offers and return stats.
+     *
+     * @return array{sent:int,batchId:int}
+     */
+    public function notify(int $ttlDays): array
+    {
+        $assignBatch = Batch::query()->where('type', 'assign')->whereNotNull('finished_at')
+            ->latest('id')->first();
+
+        if (!$assignBatch) {
+            throw new RuntimeException('Kein Assign-Batch gefunden.');
+        }
+
+        $channelIds = Assignment::query()->where('batch_id', $assignBatch->id)
+            ->whereIn('status', ['queued', 'notified'])
+            ->pluck('channel_id')->unique()->values();
+
+        if ($channelIds->isEmpty()) {
+            return ['sent' => 0, 'batchId' => $assignBatch->id];
+        }
+
+        $sent = 0;
+        foreach (Channel::query()->whereIn('id', $channelIds)->get() as $channel) {
+            $offerUrl = URL::temporarySignedRoute(
+                'offer.show',
+                now()->addDays($ttlDays),
+                ['batch' => $assignBatch->id, 'channel' => $channel->id]
+            );
+
+            Mail::to($channel->email)->queue(
+                new NewOfferMail($assignBatch, $channel, $offerUrl, now()->addDays($ttlDays))
+            );
+            $sent++;
+        }
+
+        Batch::query()->create([
+            'type' => 'notify',
+            'started_at' => now(),
+            'finished_at' => now(),
+            'stats' => ['emails' => $sent]
+        ]);
+
+        return ['sent' => $sent, 'batchId' => $assignBatch->id];
+    }
+}
+


### PR DESCRIPTION
## Summary
- Extract heavy command logic into dedicated services for distribution, expiration, notifications and ingestion
- Simplify console commands to delegate to these services
- Allow configurable TTL when preparing assignment download links

## Testing
- `APP_KEY=base64:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa= ./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6895d35f3f50832980191b0c2da7880a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced new services for distributing assignments, expiring assignments, scanning and ingesting videos, and notifying channels and offers, streamlining related processes.

* **Refactor**
  * Console commands for assignment distribution, expiration, ingest scanning, and notifications have been refactored to delegate logic to dedicated service classes, resulting in clearer and more maintainable command outputs.

* **Improvements**
  * Enhanced download link expiration flexibility by allowing custom expiration periods for assignment downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->