### PR TITLE
refactor: clean up console commands

### DIFF
--- a/app/Console/Commands/AssignDistribute.php
+++ b/app/Console/Commands/AssignDistribute.php
@@ -22,11 +22,11 @@ class AssignDistribute extends Command
     {
         try {
             $quota = $this->option('quota');
-            $stats = $this->distributor->distribute($quota !== null ? (int)$quota : null);
+            $stats = $this->distributor->distribute($quota !== null ? (int) $quota : null);
             $this->info("Assigned={$stats['assigned']}, skipped={$stats['skipped']}");
         } catch (RuntimeException $e) {
             $this->warn($e->getMessage());
         }
-        return 0;
+        return self::SUCCESS;
     }
 }

--- a/app/Console/Commands/AssignExpire.php
+++ b/app/Console/Commands/AssignExpire.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 // app/Console/Commands/AssignExpire.php
 namespace App\Console\Commands;
 
@@ -17,9 +19,9 @@ class AssignExpire extends Command
 
     public function handle(): int
     {
-        $cooldownDays = (int)$this->option('cooldown-days');
-        $cnt = $this->expirer->expire($cooldownDays);
-        $this->info("Expired: $cnt");
-        return 0;
+        $cooldownDays = (int) $this->option('cooldown-days');
+        $expiredCount = $this->expirer->expire($cooldownDays);
+        $this->info("Expired: {$expiredCount}");
+        return self::SUCCESS;
     }
 }

--- a/app/Console/Commands/NotifyOffers.php
+++ b/app/Console/Commands/NotifyOffers.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace App\Console\Commands;
 
@@ -18,7 +19,7 @@ class NotifyOffers extends Command
 
     public function handle(): int
     {
-        $ttlDays = (int)$this->option('ttl-days');
+        $ttlDays = (int) $this->option('ttl-days');
 
         try {
             $result = $this->notifier->notify($ttlDays);
@@ -30,6 +31,7 @@ class NotifyOffers extends Command
         } catch (RuntimeException $e) {
             $this->warn($e->getMessage());
         }
-        return 0;
+        return self::SUCCESS;
     }
 }
+

--- a/app/Console/Commands/WeeklyRun.php
+++ b/app/Console/Commands/WeeklyRun.php
@@ -16,6 +16,6 @@ class WeeklyRun extends Command
         $this->call('assign:expire');
         $this->call('assign:distribute');
         $this->call('notify:offers');
-        return 0;
+        return self::SUCCESS;
     }
 }


### PR DESCRIPTION
## Summary
- enforce strict types and success/failure constants across Artisan commands
- clarify counter variable names for better readability

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_6895e58bc5108329878573bc98731f62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved code style and consistency across several commands, including variable naming and formatting adjustments.
  * Standardized exit codes by replacing integer literals with predefined success and failure constants.
  * Added strict type declarations to relevant files for better type safety.

* **Chores**
  * Enhanced clarity and maintainability through more descriptive variable names and consistent output formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->