### PR TITLE
Allow channels to release unused videos

### DIFF
--- a/app/Http/Controllers/OfferController.php
+++ b/app/Http/Controllers/OfferController.php
@@ -69,6 +69,53 @@ class OfferController extends Controller
         return response()->noContent();
     }
 
+    public function showUnused(Request $req, Batch $batch, Channel $channel)
+    {
+        $this->ensureValidSignature($req);
+
+        $items = Assignment::with('video')
+            ->where('batch_id', $batch->id)
+            ->where('channel_id', $channel->id)
+            ->where('status', 'picked_up')
+            ->get();
+
+        $postUrl = URL::temporarySignedRoute(
+            'offer.unused.store',
+            now()->addHours(6),
+            ['batch' => $batch->id, 'channel' => $channel->id]
+        );
+
+        return view('offer.unused', compact('batch', 'channel', 'items', 'postUrl'));
+    }
+
+    public function storeUnused(Request $req, Batch $batch, Channel $channel)
+    {
+        $this->ensureValidSignature($req);
+
+        $ids = collect($req->input('assignment_ids', []))
+            ->filter(fn ($v) => ctype_digit((string) $v))
+            ->map('intval')
+            ->values();
+
+        if ($ids->isEmpty()) {
+            return back()->withErrors(['nothing' => 'Bitte wähle mindestens ein Video aus.']);
+        }
+
+        Assignment::query()
+            ->where('batch_id', $batch->id)
+            ->where('channel_id', $channel->id)
+            ->whereIn('id', $ids)
+            ->where('status', 'picked_up')
+            ->update([
+                'status' => 'queued',
+                'download_token' => null,
+                'expires_at' => null,
+                'last_notified_at' => null,
+            ]);
+
+        return back()->with('success', 'Die ausgewählten Videos wurden wieder freigegeben.');
+    }
+
     private function ensureValidSignature(Request $req): void
     {
         abort_unless($req->hasValidSignature(), 403);

--- a/app/Mail/NewOfferMail.php
+++ b/app/Mail/NewOfferMail.php
@@ -16,6 +16,7 @@ class NewOfferMail extends Mailable
         public Channel $channel,
         public string $offerUrl,
         public \Carbon\Carbon $expiresAt,
+        public string $unusedUrl,
     ) {
     }
 

--- a/app/Services/OfferNotifier.php
+++ b/app/Services/OfferNotifier.php
@@ -41,8 +41,14 @@ class OfferNotifier
                 ['batch' => $assignBatch->id, 'channel' => $channel->id]
             );
 
+            $unusedUrl = URL::temporarySignedRoute(
+                'offer.unused.show',
+                now()->addDays($ttlDays),
+                ['batch' => $assignBatch->id, 'channel' => $channel->id]
+            );
+
             Mail::to($channel->email)->queue(
-                new NewOfferMail($assignBatch, $channel, $offerUrl, now()->addDays($ttlDays))
+                new NewOfferMail($assignBatch, $channel, $offerUrl, now()->addDays($ttlDays), $unusedUrl)
             );
             $sent++;
         }

--- a/resources/views/emails/new-offer.blade.php
+++ b/resources/views/emails/new-offer.blade.php
@@ -17,6 +17,8 @@
     Dieser Link ist gültig bis **{{ $expires_at->format('d.m.Y H:i') }}**.
     Danach werden die Dateien automatisch aus unserem System entfernt.
 
+    [Du willst doch Videos nicht verwenden? Sei so fair und teil es mit, damit andere Kanäle profitieren können]({{ $unusedUrl }})
+
     Viele Grüße
     {{ config('app.name') }}
 @endcomponent

--- a/resources/views/offer/unused.blade.php
+++ b/resources/views/offer/unused.blade.php
@@ -1,0 +1,41 @@
+@extends('layouts.app')
+
+@section('title', 'Nicht verwendete Videos – '.$channel->name)
+@section('subtitle', 'Batch #'.$batch->id)
+
+@section('content')
+    @if(session('success'))
+        <div class="panel flash--ok" style="margin-bottom:16px;">{{ session('success') }}</div>
+    @endif
+
+    @if ($errors->any())
+        <div class="panel flash--err" style="margin-bottom:16px;">
+            <strong>Es gab ein Problem:</strong>
+            <ul style="margin:6px 0 0 18px;">
+                @foreach ($errors->all() as $e)
+                    <li>{{ $e }}</li>
+                @endforeach
+            </ul>
+        </div>
+    @endif
+
+    @if($items->isEmpty())
+        <div class="panel">Es gibt aktuell keine heruntergeladenen Videos, die du freigeben könntest.</div>
+    @else
+        <form method="POST" action="{{ $postUrl }}">
+            @csrf
+            <ul style="list-style:none;padding:0;">
+                @foreach($items as $a)
+                    @php($v = $a->video)
+                    <li style="margin-bottom:8px;">
+                        <label style="display:flex;align-items:center;gap:8px;">
+                            <input type="checkbox" name="assignment_ids[]" value="{{ $a->id }}">
+                            <span>{{ $v->original_name ?: basename($v->path) }}</span>
+                        </label>
+                    </li>
+                @endforeach
+            </ul>
+            <button type="submit" class="btn">Ausgewählte Videos freigeben</button>
+        </form>
+    @endif
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,5 +11,7 @@ Route::get('/', function () {
 
 Route::get('/offer/{batch}/{channel}', [OfferController::class, 'show'])->name('offer.show');
 Route::post('/offer/{batch}/{channel}/zip', [OfferController::class, 'zipSelected'])->name('offer.zip.selected');
+Route::get('/offer/{batch}/{channel}/unused', [OfferController::class, 'showUnused'])->name('offer.unused.show');
+Route::post('/offer/{batch}/{channel}/unused', [OfferController::class, 'storeUnused'])->name('offer.unused.store');
 
 Route::get('/d/{assignment}', [AssignmentDownloadController::class, 'download'])->name('assignments.download');


### PR DESCRIPTION
## Summary
- Add ability for creators to return unused videos via new OfferController endpoints and view
- Include link in new offer email to unused-video form and pass URL through notifier/mailable
- Register routes for selecting and releasing unused videos

## Testing
- `APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= composer test`


------
https://chatgpt.com/codex/tasks/task_e_6895f04afcdc832984359a1a6e159fb2