### PR TITLE
Refactor IngestScan command to use service

### DIFF
--- a/app/Console/Commands/IngestScan.php
+++ b/app/Console/Commands/IngestScan.php
@@ -5,161 +5,37 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
-use App\Models\{Batch, Video};
+use App\Services\IngestScanner;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Storage;
-use Spatie\Dropbox\Client as DropboxClient;
+use RuntimeException;
 
 class IngestScan extends Command
 {
-    protected $signature = 'ingest:scan 
-        {--inbox=/srv/ingest/pending : Wurzelordner der Uploads (rekursiv)} 
+    protected $signature = 'ingest:scan
+        {--inbox=/srv/ingest/pending : Wurzelordner der Uploads (rekursiv)}
         {--disk= : Ziel-Storage-Disk (z.B. dropbox|local; überschreibt Config)}';
 
     protected $description = 'Scannt Inbox rekursiv, dedupe per SHA-256, verschiebt content-addressiert auf konfiguriertes Storage.';
 
+    public function __construct(private IngestScanner $scanner)
+    {
+        parent::__construct();
+    }
+
     public function handle(): int
     {
-        $inbox = rtrim((string)$this->option('inbox'), '/');
-        $diskName = (string)($this->option('disk') ?: config('files.video_disk', env('FILES_VIDEOS_DISK', 'dropbox')));
-        $disk = Storage::disk($diskName);
+        $inbox = rtrim((string) $this->option('inbox'), '/');
+        $diskName = (string) ($this->option('disk') ?: config('files.video_disk', env('FILES_VIDEOS_DISK', 'dropbox')));
         $this->info('started...');
 
-        if (!is_dir($inbox)) {
-            $this->error("Inbox fehlt: {$inbox}");
+        try {
+            $stats = $this->scanner->scan($inbox, $diskName);
+            $this->info("Ingest done. new={$stats['new']} dups={$stats['dups']} err={$stats['err']} disk={$diskName}");
+            return self::SUCCESS;
+        } catch (RuntimeException $e) {
+            $this->error($e->getMessage());
             return self::FAILURE;
         }
-
-        $batch = Batch::create(['type' => 'ingest', 'started_at' => now()]);
-
-        $allowed = ['mp4', 'mov', 'mkv', 'avi', 'm4v', 'webm'];
-        $newCount = 0;
-        $dupCount = 0;
-        $errorCount = 0;
-
-        $it = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($inbox, \FilesystemIterator::SKIP_DOTS),
-            \RecursiveIteratorIterator::SELF_FIRST
-        );
-
-        /**
-         * @var \SplFileInfo $fileInfo
-         */
-        foreach ($it as $path => $fileInfo) {
-            if (!$fileInfo->isFile()) {
-                continue;
-            }
-
-            $ext = strtolower($fileInfo->getExtension());
-            if (!in_array($ext, $allowed, true)) {
-                continue;
-            } // CSV, TXT etc. ignorieren
-
-            $fileName = $fileInfo->getFilename();
-
-            try {
-                $this->info('processing file: '.$fileName);
-                // Hash & Bytes von der lokalen Quelle ermitteln
-                $hash = hash_file('sha256', $path);
-                $bytes = filesize($path);
-
-                // Duplicate? -> lokale Datei löschen und weiter
-                if (Video::query()->where('hash', $hash)->exists()) {
-                    $this->info('duplicated file: '.$fileName);
-                    @unlink($path);
-                    $dupCount++;
-                    continue;
-                }
-
-                // Content-addressierter Zielpfad
-                $sub = substr($hash, 0, 2).'/'.substr($hash, 2, 2);
-                $dstRel = "videos/{$sub}/{$hash}".($ext ? ".{$ext}" : '');
-
-                // Upload als Stream (Cloud-kompatibel), dann Quelle löschen
-                $read = fopen($path, 'rb');
-                if ($read === false) {
-                    throw new \RuntimeException("Konnte Quelle nicht öffnen: {$path}");
-                }
-
-                // Für Cloud-Disks kein makeDirectory nötig
-                $this->info('uploading file: '.$fileName);
-                $this->info($dstRel);
-
-                $uploadedSuccess = false;
-                if ($diskName === 'dropbox') {
-                    $chunkSize = 8 * 1024 * 1024; // 8MB
-                    $root = config('filesystems.disks.dropbox.root', '');
-                    $targetPath = '/' . trim($root . '/' . $dstRel, '/');
-                    $client = new DropboxClient(config('filesystems.disks.dropbox.authorization_token'));
-
-                    $bar = $this->output->createProgressBar($bytes);
-                    $bar->start();
-
-                    $firstChunk = fread($read, $chunkSize);
-                    $cursor = $client->uploadSessionStart($firstChunk);
-                    $bar->advance(strlen($firstChunk));
-
-                    if (strlen($firstChunk) < $bytes) {
-                        while (!feof($read)) {
-                            $chunk = fread($read, $chunkSize);
-                            if (feof($read)) {
-                                $client->uploadSessionFinish($chunk, $cursor, $targetPath);
-                            } else {
-                                $cursor = $client->uploadSessionAppend($chunk, $cursor);
-                            }
-                            $bar->advance(strlen($chunk));
-                        }
-                    } else {
-                        $client->uploadSessionFinish('', $cursor, $targetPath);
-                    }
-
-                    $bar->finish();
-                    $this->newLine();
-                    fclose($read);
-                    @unlink($path);
-                    $uploadedSuccess = true;
-                } else {
-                    $this->line('hochladen…');
-                    $uploadedSuccess = $disk->put($dstRel, $read);
-                    if (is_resource($read)) {
-                        fclose($read);
-                    }
-                    if ($uploadedSuccess) {
-                        @unlink($path);
-                    }
-                }
-
-                if ($uploadedSuccess) {
-                    // DB-Eintrag
-                    Video::query()->create([
-                        'hash' => $hash,
-                        'ext' => $ext,
-                        'bytes' => $bytes,
-                        'path' => $dstRel,
-                        'disk' => $diskName,
-                        'meta' => null,
-                        'original_name' => $fileName,
-                    ]);
-
-                    $newCount++;
-                    $this->info('finished file: '.$fileName);
-                } else {
-                    $errorCount++;
-                    $this->error('error file: '.$fileName);
-                }
-            } catch (\Throwable $e) {
-                $this->error($e->getMessage());
-                $errorCount++;
-            }
-        }
-
-        $batch->update([
-            'finished_at' => now(),
-            'stats' => ['new' => $newCount, 'dups' => $dupCount, 'err' => $errorCount, 'disk' => $diskName],
-        ]);
-
-        $this->info("Ingest done. new={$newCount} dups={$dupCount} err={$errorCount} disk={$diskName}");
-        return self::SUCCESS;
     }
 }
 

--- a/app/Services/IngestScanner.php
+++ b/app/Services/IngestScanner.php
@@ -7,59 +7,150 @@ namespace App\Services;
 use App\Models\{Batch, Video};
 use Illuminate\Support\Facades\{Log, Storage};
 use RuntimeException;
+use Spatie\Dropbox\Client as DropboxClient;
+use Throwable;
 
 class IngestScanner
 {
+    private const ALLOWED_EXTENSIONS = ['mp4', 'mov', 'mkv', 'avi', 'm4v', 'webm'];
+
     /**
-     * Scan an inbox for new videos, deduplicate and move them to storage.
+     * Scan an inbox recursively and ingest new videos.
      *
-     * @return array{new:int, dups:int}
+     * @return array{new:int, dups:int, err:int}
      */
-    public function scan(string $inbox): array
+    public function scan(string $inbox, string $diskName): array
     {
-        $batch = Batch::query()->create(['type' => 'ingest', 'started_at' => now()]);
         if (!is_dir($inbox)) {
-            $batch->update(['finished_at' => now(), 'stats' => ['new' => 0, 'dups' => 0]]);
-            throw new RuntimeException("Inbox $inbox fehlt");
+            throw new RuntimeException("Inbox fehlt: {$inbox}");
         }
 
-        $cntNew = $cntDup = 0;
-        foreach (glob($inbox.'/*') as $src) {
-            if (!is_file($src)) {
+        $batch = Batch::query()->create(['type' => 'ingest', 'started_at' => now()]);
+        $stats = ['new' => 0, 'dups' => 0, 'err' => 0];
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($inbox, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::SELF_FIRST
+        );
+
+        foreach ($iterator as $path => $fileInfo) {
+            if (!$fileInfo->isFile() || !$this->isAllowedExtension($fileInfo)) {
                 continue;
             }
+
             try {
-                $hash = hash_file('sha256', $src);
-                $ext = strtolower(pathinfo($src, PATHINFO_EXTENSION));
-                $orig = basename($src); // Original-Name aus der Inbox
-
-
-                if (Video::query()->where('hash', $hash)->exists()) {
-                    unlink($src);
-                    $cntDup++;
-                    continue;
-                }
-
-                $sub = substr($hash, 0, 2).'/'.substr($hash, 2, 2);
-                $dstRel = "videos/$sub/$hash".($ext ? ".$ext" : "");
-                Storage::makeDirectory("videos/$sub");
-                rename($src, Storage::path($dstRel));
-
-                Video::query()->create([
-                    'hash' => $hash,
-                    'ext' => $ext,
-                    'bytes' => filesize(Storage::path($dstRel)),
-                    'path' => $dstRel,
-                    'meta' => null,
-                    'original_name' => $orig,
-                ]);
-                $cntNew++;
-            } catch (\Throwable $e) {
+                $result = $this->processFile($path, strtolower($fileInfo->getExtension()), $fileInfo->getFilename(), $diskName);
+                $stats[$result]++;
+            } catch (Throwable $e) {
                 Log::error($e->getMessage());
+                $stats['err']++;
             }
         }
-        $batch->update(['finished_at' => now(), 'stats' => ['new' => $cntNew, 'dups' => $cntDup]]);
-        return ['new' => $cntNew, 'dups' => $cntDup];
+
+        $batch->update([
+            'finished_at' => now(),
+            'stats' => ['new' => $stats['new'], 'dups' => $stats['dups'], 'err' => $stats['err'], 'disk' => $diskName],
+        ]);
+
+        return $stats;
+    }
+
+    private function isAllowedExtension(\SplFileInfo $file): bool
+    {
+        return in_array(strtolower($file->getExtension()), self::ALLOWED_EXTENSIONS, true);
+    }
+
+    /**
+     * @return 'new'|'dups'|'err'
+     */
+    private function processFile(string $path, string $ext, string $fileName, string $diskName): string
+    {
+        $hash = hash_file('sha256', $path);
+        $bytes = filesize($path);
+
+        if (Video::query()->where('hash', $hash)->exists()) {
+            @unlink($path);
+            return 'dups';
+        }
+
+        $dstRel = $this->buildDestinationPath($hash, $ext);
+        $uploaded = $this->uploadFile($path, $dstRel, $diskName, $bytes);
+
+        if (!$uploaded) {
+            return 'err';
+        }
+
+        Video::query()->create([
+            'hash' => $hash,
+            'ext' => $ext,
+            'bytes' => $bytes,
+            'path' => $dstRel,
+            'disk' => $diskName,
+            'meta' => null,
+            'original_name' => $fileName,
+        ]);
+
+        return 'new';
+    }
+
+    private function buildDestinationPath(string $hash, string $ext): string
+    {
+        $sub = substr($hash, 0, 2) . '/' . substr($hash, 2, 2);
+        return "videos/{$sub}/{$hash}" . ($ext ? ".{$ext}" : '');
+    }
+
+    private function uploadFile(string $path, string $dstRel, string $diskName, int $bytes): bool
+    {
+        $read = fopen($path, 'rb');
+        if ($read === false) {
+            throw new RuntimeException("Konnte Quelle nicht öffnen: {$path}");
+        }
+
+        try {
+            if ($diskName === 'dropbox') {
+                $this->uploadToDropbox($read, $dstRel, $bytes);
+                fclose($read);
+                @unlink($path);
+                return true;
+            }
+
+            $disk = Storage::disk($diskName);
+            $uploaded = $disk->put($dstRel, $read);
+            if (is_resource($read)) {
+                fclose($read);
+            }
+            if ($uploaded) {
+                @unlink($path);
+            }
+            return $uploaded;
+        } finally {
+            if (is_resource($read)) {
+                fclose($read);
+            }
+        }
+    }
+
+    private function uploadToDropbox($read, string $dstRel, int $bytes): void
+    {
+        $chunkSize = 8 * 1024 * 1024; // 8MB
+        $root = config('filesystems.disks.dropbox.root', '');
+        $targetPath = '/' . trim($root . '/' . $dstRel, '/');
+        $client = new DropboxClient(config('filesystems.disks.dropbox.authorization_token'));
+
+        $firstChunk = fread($read, $chunkSize);
+        $cursor = $client->uploadSessionStart($firstChunk);
+
+        if (strlen($firstChunk) < $bytes) {
+            while (!feof($read)) {
+                $chunk = fread($read, $chunkSize);
+                if (feof($read)) {
+                    $client->uploadSessionFinish($chunk, $cursor, $targetPath);
+                } else {
+                    $cursor = $client->uploadSessionAppend($chunk, $cursor);
+                }
+            }
+        } else {
+            $client->uploadSessionFinish('', $cursor, $targetPath);
+        }
     }
 }
-


### PR DESCRIPTION
## Summary
- Simplify IngestScan command by delegating work to IngestScanner service
- Add IngestScanner service for recursive scanning, deduplication, and disk uploads with Dropbox support

## Testing
- `APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= composer test`


------
https://chatgpt.com/codex/tasks/task_e_68961a0b3ea08329876da9f6fa0443f0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced file ingestion now supports scanning all subfolders within the inbox and filters for allowed video file types.
  * Dropbox uploads are now supported, including large files through chunked upload.

* **Improvements**
  * Users receive a summary after each scan, including counts of new files, duplicates, and errors.
  * Improved error handling ensures more robust processing and clearer feedback in case of issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->