### PR TITLE
feat: add video preview links

### DIFF
--- a/app/Http/Controllers/OfferController.php
+++ b/app/Http/Controllers/OfferController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\{Assignment, Batch, Channel, Download};
-use App\Services\{AssignmentService, PreviewService};
+use App\Services\AssignmentService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\{Storage, URL};
 use Illuminate\Support\Str;
@@ -12,7 +12,7 @@ use ZipStream\ZipStream;
 
 class OfferController extends Controller
 {
-    public function __construct(private AssignmentService $assignments, private PreviewService $previews)
+    public function __construct(private AssignmentService $assignments)
     {
     }
 
@@ -26,22 +26,6 @@ class OfferController extends Controller
 
         foreach ($items as $assignment) {
             $assignment->temp_url = $this->assignments->prepareDownload($assignment);
-
-            $previewUrl = $assignment->temp_url;
-            $clip = $assignment->video->clips->first();
-
-            if ($clip && $clip->start_sec !== null && $clip->end_sec !== null) {
-                $existing = $this->previews->url(
-                    $assignment->video,
-                    (int) $clip->start_sec,
-                    (int) $clip->end_sec
-                );
-                if ($existing) {
-                    $previewUrl = $existing;
-                }
-            }
-
-            $assignment->preview_url = $previewUrl;
         }
 
         $zipPostUrl = URL::temporarySignedRoute(

--- a/app/Models/Video.php
+++ b/app/Models/Video.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Video extends Model
 {
-    protected $fillable = ['hash', 'ext', 'bytes', 'path', 'meta', 'original_name', 'disk'];
+    protected $fillable = ['hash', 'ext', 'bytes', 'path', 'meta', 'original_name', 'disk', 'preview_url'];
     protected $casts = ['meta' => 'array'];
 
     public function assignments(): HasMany

--- a/database/migrations/2025_08_08_110100_add_preview_url_to_videos_table.php
+++ b/database/migrations/2025_08_08_110100_add_preview_url_to_videos_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('videos', function (Blueprint $t) {
+            $t->string('preview_url')->nullable()->after('meta');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('videos', function (Blueprint $t) {
+            $t->dropColumn('preview_url');
+        });
+    }
+};

--- a/resources/views/offer/show.blade.php
+++ b/resources/views/offer/show.blade.php
@@ -63,7 +63,7 @@
                                              style="width:100%;height:auto;border-radius:10px;background:#0e1116;">
                                     @else
                                         <video class="thumb"
-                                               src="{{ $a->preview_url }}"
+                                               src="{{ $v->preview_url ?: $a->temp_url }}"
                                                preload="metadata"
                                                style="width:100%;height:auto;border-radius:10px;background:#0e1116;"
                                                controls playsinline></video>
@@ -106,7 +106,7 @@
                                     {{-- größere Vorschau (optional) --}}
                                     <div class="inline-preview" style="display:none; margin-top:8px;">
                                         <video controls preload="metadata" style="width:100%; border-radius:10px;">
-                                            <source src="{{ $a->preview_url }}" type="video/mp4"/>
+                                            <source src="{{ $v->preview_url ?: $a->temp_url }}" type="video/mp4"/>
                                             Dein Browser unterstützt das Video-Tag nicht.
                                         </video>
                                     </div>


### PR DESCRIPTION
## Summary
- track preview URL on videos
- generate previews for videos lacking one
- show stored preview in offers

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68965b469c948329b8f6813c3def19ef

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for storing and displaying video preview URLs for videos without existing previews.
  * Updated the interface to show video previews using the new preview URL when available.

* **Bug Fixes**
  * Improved logic to ensure previews are only generated for videos lacking a preview.

* **Chores**
  * Updated database to include a new field for video preview URLs.
  * Refined command descriptions and removed unused preview generation logic from certain controllers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->