### PR TITLE
Generate previews for defined clip time ranges

### DIFF
--- a/app/Services/PreviewService.php
+++ b/app/Services/PreviewService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\Models\Video;
+use App\Models\Clip;
 use Illuminate\Console\OutputStyle;
 use Illuminate\Contracts\Filesystem\Filesystem as FilesystemContract;
 use Illuminate\Support\Facades\Log;
@@ -20,6 +21,25 @@ final class PreviewService
     public function setOutput(?OutputStyle $outputStyle = null): void
     {
         $this->output = $outputStyle;
+    }
+
+    public function generateForClip(Clip $clip): ?string
+    {
+        $video = $clip->video;
+        if (!$video) {
+            $this->warn('Clip ohne zugehöriges Video.');
+            return null;
+        }
+
+        $start = $clip->start_sec;
+        $end = $clip->end_sec;
+
+        if ($start === null || $end === null) {
+            $this->warn("Clip {$clip->id} hat keinen gültigen Zeitbereich.");
+            return null;
+        }
+
+        return $this->generate($video, $start, $end);
     }
 
     public function generate(Video $video, int $start, int $end): ?string


### PR DESCRIPTION
## Summary
- add `generateForClip` to build previews for a clip's start/end range
- during ingest, import clip info and prefer clip-based preview generation
- use `InfoImporter` directly instead of `Artisan` for clip CSV imports

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68967513c8088329bb8cecedb9a9efe2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of CSV and TXT file imports, with each file processed individually and deleted if no warnings occur.
  * Enhanced preview generation now creates clip-specific previews when start and end times are defined.
  * Added support for generating previews directly from video clips.

* **Bug Fixes**
  * Improved error logging with additional context for easier troubleshooting during import failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->