### PR TITLE
Consider bundles in assignment distribution

### DIFF
--- a/app/Services/AssignmentDistributor.php
+++ b/app/Services/AssignmentDistributor.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services;
 
-use App\Models\{Assignment, Batch, Channel, ChannelVideoBlock, Video};
+use App\Models\{Assignment, Batch, Channel, ChannelVideoBlock, Clip, Video};
 use Illuminate\Support\Facades\DB;
 use RuntimeException;
 
@@ -34,6 +34,21 @@ class AssignmentDistributor
             throw new RuntimeException('Nichts zu verteilen.');
         }
 
+        $bundleKeys = Clip::query()
+            ->whereIn('video_id', $poolVideos->pluck('id'))
+            ->whereNotNull('bundle_key')
+            ->pluck('bundle_key')
+            ->unique();
+
+        if ($bundleKeys->isNotEmpty()) {
+            $bundleVideoIds = Clip::query()
+                ->whereIn('bundle_key', $bundleKeys)
+                ->pluck('video_id')
+                ->unique();
+            $bundleVideos = Video::query()->whereIn('id', $bundleVideoIds)->get();
+            $poolVideos = $poolVideos->concat($bundleVideos)->unique('id')->values();
+        }
+
         $channels = Channel::query()->orderBy('id')->get();
         if ($channels->isEmpty()) {
             $batch->update(['finished_at' => now(), 'stats' => ['assigned' => 0]]);
@@ -46,12 +61,39 @@ class AssignmentDistributor
 
         $quota = $channels->mapWithKeys(fn($c) => [$c->id => (int)($quotaOverride ?: $c->weekly_quota)]);
 
+        $groups = collect();
+        $handled = [];
+        $bundleMap = Clip::query()
+            ->whereIn('video_id', $poolVideos->pluck('id'))
+            ->whereNotNull('bundle_key')
+            ->get()
+            ->groupBy('bundle_key')
+            ->map(fn($g) => $g->pluck('video_id')->unique());
+
+        foreach ($poolVideos as $v) {
+            if (in_array($v->id, $handled, true)) {
+                continue;
+            }
+            $bundleIds = $bundleMap->first(fn($ids) => $ids->contains($v->id));
+            if ($bundleIds) {
+                $group = $poolVideos->whereIn('id', $bundleIds)->values();
+                $handled = array_merge($handled, $bundleIds->all());
+            } else {
+                $group = collect([$v]);
+                $handled[] = $v->id;
+            }
+            $groups->push($group);
+        }
+
         $assigned = 0;
         $skipped = 0;
-        foreach ($poolVideos as $v) {
-            $blockedChannelIds = ChannelVideoBlock::query()->where('video_id', $v->id)
+        foreach ($groups as $group) {
+            $blockedChannelIds = ChannelVideoBlock::query()
+                ->whereIn('video_id', $group->pluck('id'))
                 ->where('until', '>', now())
-                ->pluck('channel_id')->all();
+                ->pluck('channel_id')
+                ->unique()
+                ->all();
 
             $target = null;
             $rotations = 0;
@@ -60,13 +102,14 @@ class AssignmentDistributor
                 $pool->push($pool->shift());
                 $rotations++;
 
-                if ($quota[$candidate->id] <= 0) {
+                if ($quota[$candidate->id] < $group->count()) {
                     continue;
                 }
                 if (in_array($candidate->id, $blockedChannelIds, true)) {
                     continue;
                 }
-                $exists = Assignment::query()->where('video_id', $v->id)
+                $exists = Assignment::query()
+                    ->whereIn('video_id', $group->pluck('id'))
                     ->where('channel_id', $candidate->id)
                     ->exists();
                 if ($exists) {
@@ -77,19 +120,20 @@ class AssignmentDistributor
             }
 
             if (!$target) {
-                $skipped++;
+                $skipped += $group->count();
                 continue;
             }
 
-            Assignment::query()->create([
-                'video_id' => $v->id,
-                'channel_id' => $target->id,
-                'batch_id' => $batch->id,
-                'status' => 'queued',
-                'attempts' => DB::raw('attempts'),
-            ]);
-            $quota[$target->id]--;
-            $assigned++;
+            foreach ($group as $v) {
+                Assignment::query()->create([
+                    'video_id' => $v->id,
+                    'channel_id' => $target->id,
+                    'batch_id' => $batch->id,
+                    'status' => 'queued',
+                ]);
+                $quota[$target->id] = $quota[$target->id] - 1;
+                $assigned++;
+            }
 
             if (collect($quota->all())->every(fn($q) => $q <= 0)) {
                 break;

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Contracts\Console\Kernel;
+
+trait CreatesApplication
+{
+    public function createApplication()
+    {
+        $app = require __DIR__.'/../bootstrap/app.php';
+        $app->make(Kernel::class)->bootstrap();
+
+        return $app;
+    }
+}

--- a/tests/Feature/AssignmentDistributorBundleTest.php
+++ b/tests/Feature/AssignmentDistributorBundleTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\{Assignment, Clip, Video};
+use App\Services\AssignmentDistributor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AssignmentDistributorBundleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_bundle_videos_are_assigned_together(): void
+    {
+        $v1 = Video::create(['hash' => 'h1', 'path' => 'p1']);
+        $v2 = Video::create(['hash' => 'h2', 'path' => 'p2']);
+        Clip::create(['video_id' => $v1->id, 'bundle_key' => 'B']);
+        Clip::create(['video_id' => $v2->id, 'bundle_key' => 'B']);
+
+        $result = (new AssignmentDistributor())->distribute();
+
+        $this->assertSame(2, $result['assigned']);
+        $assignments = Assignment::query()->whereIn('video_id', [$v1->id, $v2->id])->get();
+        $this->assertCount(2, $assignments);
+        $this->assertSame(1, $assignments->pluck('channel_id')->unique()->count());
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,5 +6,5 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    use CreatesApplication;
 }


### PR DESCRIPTION
## Summary
- Include bundled videos in assignment pool and assign groups together
- Add basic Laravel test harness and coverage for bundle assignment

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_689681876e50832991396244cfcfec1f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Videos grouped by a shared bundle key are now assigned together to the same channel, ensuring bundled videos are always distributed as a unit.
  * Added a new test to verify that bundled videos are assigned to the same channel.

* **Tests**
  * Introduced a new trait to streamline application setup in tests.
  * Updated the test base class to include the new trait for improved test initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->