### PR TITLE
Allow previews to run ffmpeg for up to an hour

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -48,7 +48,7 @@ return [
         'bin' => env('FFMPEG_BIN', '/usr/bin/ffmpeg'),
         'crf' => env('FFMPEG_CRF', 28),
         'preset' => env('FFMPEG_PRESET', 'veryfast'),
-        'timeout' => env('FFMPEG_TIMEOUT', null),      // z. B. 300
+        'timeout' => env('FFMPEG_TIMEOUT', 3600),      // max. Laufzeit in Sekunden (1h)
         'idle_timeout' => env('FFMPEG_IDLE_TIMEOUT', null), // z. B. 60
     ],
 ];


### PR DESCRIPTION
## Summary
- default ffmpeg timeout is now one hour
- PreviewService enforces a maximum runtime of one hour when invoking ffmpeg

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6896823754348329a69b674c7650589e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced a maximum timeout of 1 hour for video preview generation to prevent excessively long ffmpeg processes.

* **Style**
  * Improved code formatting and readability throughout the video preview generation service.

* **Chores**
  * Updated the default ffmpeg timeout setting to 1 hour if not specified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->