### PR TITLE
Add preview fallback to prevent errors in offer view

### DIFF
--- a/resources/views/offer/show.blade.php
+++ b/resources/views/offer/show.blade.php
@@ -51,7 +51,7 @@
                                         {{ $v->original_name ?: basename($v->path) }}
                                     </div>
                                     <video class="thumb"
-                                           src="{{ $v->preview_url}}"
+                                           src="{{ $v->preview_url ?: $a->temp_url }}"
                                            preload="metadata"
                                            style="width:100%;height:auto;border-radius:10px;background:#0e1116;"
                                            controls playsinline></video>


### PR DESCRIPTION
## Summary
- Avoid fatal errors from missing preview URLs by falling back to download URL

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68969b8276b48329b72467f9745dbba0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video loading by providing a fallback source if the main video preview is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->