### PR TITLE
Ensure long notes wrap in offer view

### DIFF
--- a/resources/views/offer/show.blade.php
+++ b/resources/views/offer/show.blade.php
@@ -62,7 +62,7 @@
 
                                     {{-- Clip-Infos inkl. submitted_by --}}
                                     @foreach($v->clips as $clip)
-                                        <div class="muted" style="margin-top:4px;">
+                                        <div class="muted" style="margin-top:4px; word-break: break-word;">
                                             @if($clip->role)
                                                 <strong>{{ $clip->role }}:</strong>
                                             @endif


### PR DESCRIPTION
## Summary
- Prevent long annotation text from overflowing in offer show view by enabling word wrapping

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6896a0da671c832991fcdea430de970b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved display of clip details in video cards by ensuring long words or continuous text wrap onto the next line, preventing overflow and horizontal scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->