### PR TITLE
Clamp long card titles for consistent layout

### DIFF
--- a/resources/views/offer/show.blade.php
+++ b/resources/views/offer/show.blade.php
@@ -47,7 +47,7 @@
                                 <input type="checkbox" name="assignment_ids[]" value="{{ $a->id }}" class="pickbox"
                                        style="margin-top:6px;">
                                 <div style="flex:1;">
-                                    <div style="font-weight:600; margin-bottom:6px;">
+                                    <div style="font-weight:600; margin-bottom:6px; word-break: break-word; overflow: hidden; display:-webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; text-overflow: ellipsis;">
                                         {{ $v->original_name ?: basename($v->path) }}
                                     </div>
                                     <video class="thumb"


### PR DESCRIPTION
## Summary
- prevent long video titles from stretching cards

## Testing
- `composer test` (warnings: missing .env)`

------
https://chatgpt.com/codex/tasks/task_e_6896a4d837448329b9fffe29ef046b2b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the display of video filenames by adding multi-line ellipsis and truncation, ensuring long names are neatly presented without overflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->