### PR TITLE
Fix assignment download path handling

### DIFF
--- a/app/Http/Controllers/AssignmentDownloadController.php
+++ b/app/Http/Controllers/AssignmentDownloadController.php
@@ -20,9 +20,11 @@ class AssignmentDownloadController extends Controller
         $valid = hash_equals($assignment->download_token, hash('sha256', $token));
         abort_unless($valid, 403);
 
-        $filePath = $assignment->video->path;
-        abort_unless(Storage::exists($filePath), 404);
-        $abs = Storage::path($filePath);
+        $video = $assignment->video;
+        $disk = Storage::disk($video->disk ?? 'local');
+        $filePath = ltrim($video->path, '/');
+        abort_unless($disk->exists($filePath), 404);
+        $abs = $disk->path($filePath);
         $size = filesize($abs);
 
         // Einfacher Stream (Hinweis: Für echtes 206-Range-Handling kannst du eine dedizierte Stream-Klasse nutzen)


### PR DESCRIPTION
## Summary
- normalize stored video paths before checking storage
- respect the video's configured disk when streaming downloads

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6896ad9558d08329bece55df5e90e79b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support for downloading video files stored on different storage disks, ensuring compatibility beyond the default storage location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->