### PR TITLE
Use stream_copy_to_stream for assignment downloads

### DIFF
--- a/app/Http/Controllers/AssignmentDownloadController.php
+++ b/app/Http/Controllers/AssignmentDownloadController.php
@@ -28,9 +28,13 @@ class AssignmentDownloadController extends Controller
         abort_unless($stream !== false, 404);
         $size = $disk->size($filePath);
 
-        // Einfacher Stream (Hinweis: Für echtes 206-Range-Handling kannst du eine dedizierte Stream-Klasse nutzen)
+        // Einfache Ausgabe als Stream ohne fpassthru (stream_copy_to_stream funktioniert auch mit Dropbox)
         $response = new StreamedResponse(function () use ($stream) {
-            fpassthru($stream);
+            $output = fopen('php://output', 'wb');
+            if ($output !== false) {
+                stream_copy_to_stream($stream, $output);
+                fclose($output);
+            }
             if (is_resource($stream)) {
                 fclose($stream);
             }


### PR DESCRIPTION
## Summary
- avoid `fpassthru` for downloads
- stream assignment videos using `stream_copy_to_stream`

## Testing
- `composer test` (with warnings)

------
https://chatgpt.com/codex/tasks/task_e_6896b21010e88329b267ba31bfe55907

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the file download process to enhance compatibility with Dropbox and ensure more reliable streaming of downloaded files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->