### PR TITLE
Refactor download zipping to dedicated controller

### DIFF
--- a/app/Http/Controllers/OfferController.php
+++ b/app/Http/Controllers/OfferController.php
@@ -2,16 +2,11 @@
 
 namespace App\Http\Controllers;
 
-use App\Enum\StatusEnum;
-use App\Models\{Assignment, Batch, Channel, Download};
+use App\Models\{Batch, Channel};
 use App\Services\AssignmentService;
 use App\Services\LinkService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\{Storage};
-use Illuminate\Support\Str;
-use ZipStream\ZipStream;
 
 class OfferController extends Controller
 {
@@ -38,42 +33,6 @@ class OfferController extends Controller
         $zipPostUrl = $linkService->getZipSelectedUrl($batch, $channel, now()->addHours(6));
 
         return view('offer.show', compact('batch', 'channel', 'items', 'zipPostUrl'));
-    }
-
-    public function zipSelected(Request $req, Batch $batch, Channel $channel)
-    {
-        $this->ensureValidSignature($req);
-
-        $ids = collect($req->input('assignment_ids', []))
-            ->filter(fn($v) => ctype_digit((string)$v))
-            ->map('intval')
-            ->values();
-
-        if ($ids->isEmpty()) {
-            return back()->withErrors(['nothing' => 'Bitte wähle mindestens ein Video aus.']);
-        }
-
-        $items = $this->assignments->fetchForZip($batch, $channel, $ids);
-
-        if ($items->isEmpty()) {
-            return back()->withErrors(['invalid' => 'Die Auswahl ist nicht mehr verfügbar.']);
-        }
-
-        $filename = sprintf('videos_%s_%s_selected.zip', $batch->getKey(), Str::slug($channel->name));
-        return response()->streamDownload(function () use ($items, $req, $filename) {
-            $zip = new ZipStream(
-                sendHttpHeaders: true, // sendet Content-Disposition & Co.
-                outputName: $filename
-            );
-
-            // Info.csv
-            $zip->addFile('info.csv', $this->buildInfoCsv($items));
-
-            // Videos hinzufügen
-            $this->addVideosToZip($zip, $items, $req);
-
-            $zip->finish(); // ganz am Ende
-        }, $filename);
     }
 
     public function showUnused(Request $req, Batch $batch, Channel $channel)
@@ -114,96 +73,4 @@ class OfferController extends Controller
         abort_unless($req->hasValidSignature(), 403);
     }
 
-    /**
-     * @param  Collection<Assignment>  $items
-     * @return string
-     */
-    private function buildInfoCsv(Collection $items): string
-    {
-        $rows = [];
-        $rows[] = ['filename', 'hash', 'size_mb', 'start', 'end', 'note', 'bundle', 'role', 'submitted_by'];
-
-        foreach ($items as $assignment) {
-            $video = $assignment->video;
-            $clips = $video->clips ?? collect();
-
-            if ($clips->isEmpty()) {
-                $rows[] = [
-                    $video->original_name ?: basename($video->path),
-                    $video->hash,
-                    number_format(($video->bytes ?? 0) / 1048576, 1, '.', ''),
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                ];
-            } else {
-                foreach ($clips as $clip) {
-                    $rows[] = [
-                        $video->original_name ?: basename($video->path),
-                        $video->hash,
-                        number_format(($video->bytes ?? 0) / 1048576, 1, '.', ''),
-                        isset($clip->start_sec) ? gmdate('i:s', (int)$clip->start_sec) : null,
-                        isset($clip->end_sec) ? gmdate('i:s', (int)$clip->end_sec) : null,
-                        $clip->note,
-                        $clip->bundle_key,
-                        $clip->role,
-                        $clip->submitted_by,
-                    ];
-                }
-            }
-        }
-
-        $fp = fopen('php://temp', 'w+');
-        fwrite($fp, "\xEF\xBB\xBF"); // BOM
-        foreach ($rows as $row) {
-            fputcsv($fp, $row, ';');
-        }
-        rewind($fp);
-        $csv = stream_get_contents($fp);
-        fclose($fp);
-
-        return $csv;
-    }
-
-    /**
-     * @param  ZipStream  $zip
-     * @param  Collection<Assignment>  $items
-     * @param  Request  $req
-     * @return void
-     */
-    private function addVideosToZip(ZipStream $zip, Collection $items, Request $req): void
-    {
-        foreach ($items as $assignment) {
-            $video = $assignment->video;
-            $disk = Storage::disk($v->disk ?? 'local');
-
-            if (!$disk->exists($video->path)) {
-                continue;
-            }
-
-            $stream = $disk->readStream($video->path);
-            if (!is_resource($stream)) {
-                continue;
-            }
-
-            $nameInZip = $video->original_name ?: basename($video->path);
-            $nameInZip = preg_replace('/[\\\\\/:*?"<>|]+/', '_', $nameInZip);
-
-            $zip->addFileFromStream($nameInZip, $stream);
-            fclose($stream);
-
-            $assignment->update(['status' => StatusEnum::PICKEDUP->value]);
-
-            Download::query()->create([
-                'assignment_id' => $assignment->getKey(),
-                'downloaded_at' => now(),
-                'ip' => $req->ip(),
-                'user_agent' => $req->userAgent(),
-                'bytes_sent' => null,
-            ]);
-        }
-    }
 }

--- a/app/Services/LinkService.php
+++ b/app/Services/LinkService.php
@@ -41,7 +41,7 @@ class LinkService
     public function getZipSelectedUrl(Batch $batch, Channel $channel, Carbon $expireDate): string
     {
         return URL::temporarySignedRoute(
-            'offer.zip.selected',
+            'zips.start',
             $expireDate,
             ['batch' => $batch->getKey(), 'channel' => $channel->getKey()]);
     }

--- a/app/Services/ZipService.php
+++ b/app/Services/ZipService.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace App\Services;
 
-use App\Models\Batch;
-use App\Models\Channel;
+use App\Enum\StatusEnum;
+use App\Models\{Assignment, Batch, Channel, Download};
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
@@ -13,7 +14,7 @@ use ZipArchive;
 
 class ZipService
 {
-    public function build(Batch $batch, Channel $channel, array $pathsOnDisk): string
+    public function build(Batch $batch, Channel $channel, Collection $items, string $ip, ?string $userAgent): string
     {
         $batchId = $batch->getKey();
         $name = $channel->getAttribute('name');
@@ -24,16 +25,37 @@ class ZipService
 
         $zip = new ZipArchive();
         $absPath = Storage::path($tmpPath);
-        $zip->open($absPath, ZipArchive::CREATE | \ZipArchive::OVERWRITE);
+        $zip->open($absPath, ZipArchive::CREATE | ZipArchive::OVERWRITE);
 
-        $total = max(count($pathsOnDisk), 1);
+        // Info.csv hinzufügen
+        $zip->addFromString('info.csv', $this->buildInfoCsv($items));
+
+        $total = max($items->count(), 1);
         $i = 0;
 
         Cache::put($this->key($jobId, 'status'), 'working', 600);
         Cache::put($this->key($jobId, 'progress'), 0, 600);
 
-        foreach ($pathsOnDisk as $path) {
-            $zip->addFile($path, basename($path));
+        foreach ($items as $assignment) {
+            $video = $assignment->video;
+            $disk = Storage::disk($video->disk ?? 'local');
+
+            if ($disk->exists($video->path)) {
+                $nameInZip = $video->original_name ?: basename($video->path);
+                $nameInZip = preg_replace('/[\\\\\/:*?"<>|]+/', '_', $nameInZip);
+                $zip->addFile($disk->path($video->path), $nameInZip);
+
+                $assignment->update(['status' => StatusEnum::PICKEDUP->value]);
+
+                Download::query()->create([
+                    'assignment_id' => $assignment->getKey(),
+                    'downloaded_at' => now(),
+                    'ip' => $ip,
+                    'user_agent' => $userAgent,
+                    'bytes_sent' => null,
+                ]);
+            }
+
             $i++;
             $pct = (int)floor($i * 100 / $total);
             Cache::put($this->key($jobId, 'progress'), $pct, 600);
@@ -46,6 +68,59 @@ class ZipService
         Cache::put($this->key($jobId, 'name'), $downloadName, 600);
 
         return $tmpPath;
+    }
+
+    /**
+     * @param  Collection<Assignment>  $items
+     */
+    private function buildInfoCsv(Collection $items): string
+    {
+        $rows = [];
+        $rows[] = ['filename', 'hash', 'size_mb', 'start', 'end', 'note', 'bundle', 'role', 'submitted_by'];
+
+        foreach ($items as $assignment) {
+            $video = $assignment->video;
+            $clips = $video->clips ?? collect();
+
+            if ($clips->isEmpty()) {
+                $rows[] = [
+                    $video->original_name ?: basename($video->path),
+                    $video->hash,
+                    number_format(($video->bytes ?? 0) / 1048576, 1, '.', ''),
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                ];
+            } else {
+                foreach ($clips as $clip) {
+                    $rows[] = [
+                        $video->original_name ?: basename($video->path),
+                        $video->hash,
+                        number_format(($video->bytes ?? 0) / 1048576, 1, '.', ''),
+                        isset($clip->start_sec) ? gmdate('i:s', (int)$clip->start_sec) : null,
+                        isset($clip->end_sec) ? gmdate('i:s', (int)$clip->end_sec) : null,
+                        $clip->note,
+                        $clip->bundle_key,
+                        $clip->role,
+                        $clip->submitted_by,
+                    ];
+                }
+            }
+        }
+
+        $fp = fopen('php://temp', 'w+');
+        fwrite($fp, "\xEF\xBB\xBF");
+        foreach ($rows as $row) {
+            fputcsv($fp, $row, ';');
+        }
+        rewind($fp);
+        $csv = stream_get_contents($fp);
+        fclose($fp);
+
+        return $csv;
     }
 
     public function key(string $jobId, string $suffix): string

--- a/resources/views/offer/show.blade.php
+++ b/resources/views/offer/show.blade.php
@@ -107,9 +107,7 @@
             <div style="display:flex; gap:10px; margin-top:16px;">
                 <button type="button" class="btn" onclick="toggleAll(true)">Alle auswählen</button>
                 <button type="button" class="btn" onclick="toggleAll(false)">Alle abwählen</button>
-                <button type="submit" class="btn" id="zipSubmit" disabled
-                        title="Funktion derzeit aufgrund eines Fehlers deaktiviert">Auswahl als ZIP herunterladen
-                </button>
+                <button type="button" class="btn" id="zipSubmit">Auswahl als ZIP herunterladen</button>
                 <span class="muted" id="selCount" style="align-self:center;">0 ausgewählt</span>
             </div>
         </form>
@@ -137,11 +135,16 @@
             document.addEventListener('DOMContentLoaded', updateCount);
 
             document.getElementById('zipSubmit').addEventListener('click', async () => {
-                const files = @json($filePaths); // z.B. vom Controller in die View gegeben
-                const res = await fetch('/zips', {
+                const selected = Array.from(document.querySelectorAll('.pickbox:checked')).map(cb => cb.value);
+                if (selected.length === 0) {
+                    alert('Bitte wähle mindestens ein Video aus.');
+                    return;
+                }
+                const postUrl = @json($zipPostUrl);
+                const res = await fetch(postUrl, {
                     method: 'POST',
                     headers: {'Content-Type': 'application/json', 'X-CSRF-TOKEN': '{{ csrf_token() }}'},
-                    body: JSON.stringify({files, name: 'auswahl.zip'})
+                    body: JSON.stringify({assignment_ids: selected})
                 });
                 const {id} = await res.json();
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,7 +21,7 @@ Route::get('/changelog', function () {
 
 
 Route::get('/offer/{batch}/{channel}', [OfferController::class, 'show'])->name('offer.show');
-Route::post('/offer/{batch}/{channel}/zip', [OfferController::class, 'zipSelected'])->name('offer.zip.selected');
+// ZIP-Download via asynchronen Job
 Route::get('/offer/{batch}/{channel}/unused', [OfferController::class, 'showUnused'])->name('offer.unused.show');
 Route::post('/offer/{batch}/{channel}/unused', [OfferController::class, 'storeUnused'])->name('offer.unused.store');
 
@@ -31,6 +31,6 @@ Route::get('/d/{assignment}', [AssignmentDownloadController::class, 'download'])
 Route::get('/dropbox/connect', [DropboxController::class, 'connect'])->name('dropbox.connect');
 Route::get('/dropbox/callback', [DropboxController::class, 'callback'])->name('dropbox.callback');
 
-Route::post('/zips/{batch}/{channel}', [ZipController::class, 'start']);
-Route::get('/zips/{id}/progress', [ZipController::class, 'progress']);
-Route::get('/zips/{id}/download', [ZipController::class, 'download']);
+Route::post('/zips/{batch}/{channel}', [ZipController::class, 'start'])->name('zips.start');
+Route::get('/zips/{id}/progress', [ZipController::class, 'progress'])->name('zips.progress');
+Route::get('/zips/{id}/download', [ZipController::class, 'download'])->name('zips.download');


### PR DESCRIPTION
## Summary
- Replace OfferController zipSelected with ZipController job-based workflow
- Move ZIP creation into ZipService with info.csv and download logging
- Add client-side polling for ZIP build progress

## Testing
- `php -l app/Http/Controllers/ZipController.php app/Jobs/BuildZipJob.php app/Services/ZipService.php app/Services/LinkService.php app/Http/Controllers/OfferController.php`
- `composer install` *(fails: Parse error on line 10 of composer.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898f23472948329a996c617cb4477c4