### PR TITLE
feat(admin): expand assignment listings

### DIFF
--- a/app/Filament/Resources/VideoResource/RelationManagers/AssignmentsRelationManager.php
+++ b/app/Filament/Resources/VideoResource/RelationManagers/AssignmentsRelationManager.php
@@ -23,10 +23,19 @@ class AssignmentsRelationManager extends RelationManager
             ->recordTitleAttribute('id')
             ->columns([
                 TextColumn::make('id')->sortable(),
+                TextColumn::make('channel.name')
+                    ->label('Channel')
+                    ->sortable()
+                    ->searchable(),
                 TextColumn::make('status')->badge()->sortable(),
                 TextColumn::make('attempts')->numeric()->sortable(),
                 TextColumn::make('expires_at')->dateTime()->since()->sortable(),
                 TextColumn::make('last_notified_at')->dateTime()->since()->sortable()->toggleable(),
+                TextColumn::make('video.preview_url')
+                    ->label('Preview')
+                    ->formatStateUsing(fn() => 'Open')
+                    ->url(fn(Assignment $assignment) => $assignment->video ? (string)$assignment->video->getAttribute('preview_url') : null)
+                    ->openUrlInNewTab(),
                 TextColumn::make('created_at')->dateTime()->since()->sortable(),
             ])
             ->headerActions([]) // read-only


### PR DESCRIPTION
## Summary
- show channel, preview and offer links in assignment list
- expose channel and preview info on video assignment relation

## Testing
- `composer test` *(fails: Cannot redeclare class App\Filament\Resources\AssignmentResource)*

------
https://chatgpt.com/codex/tasks/task_e_689924302bc083299b04c9f553a507dd