### PR TITLE
Use jobId for zip download polling and enhance modal

### DIFF
--- a/resources/js/components/DownloadModal.js
+++ b/resources/js/components/DownloadModal.js
@@ -6,15 +6,17 @@ export default class DownloadModal {
         this.modal.innerHTML = `
             <div class="panel" style="max-width:400px;width:90%;">
                 <h3>Download läuft...</h3>
-                <ul id="downloadFileList" style="margin:12px 0 16px 18px; list-style:disc;"></ul>
+                <ul id="downloadFileList" class="my-3 ml-4 list-disc"></ul>
                 <div class="w-full h-2 bg-gray-200 rounded overflow-hidden">
                     <div id="zipProgressBar" class="h-full w-0 bg-blue-500 transition-all"></div>
                 </div>
-                <button type="button" id="closeModal" class="btn" style="margin-top:16px; display:none;">Schließen</button>
+                <p id="progressText" class="text-right text-sm mt-1">0%</p>
+                <button type="button" id="closeModal" class="btn mt-4 hidden">Schließen</button>
             </div>`;
         document.body.appendChild(this.modal);
         this.fileList = this.modal.querySelector('#downloadFileList');
         this.progressBar = this.modal.querySelector('#zipProgressBar');
+        this.progressText = this.modal.querySelector('#progressText');
         this.closeBtn = this.modal.querySelector('#closeModal');
     }
 
@@ -26,16 +28,19 @@ export default class DownloadModal {
             this.fileList.appendChild(li);
         });
         this.progressBar.style.width = '0%';
-        this.closeBtn.style.display = 'none';
+        this.progressText.textContent = '0%';
+        this.closeBtn.classList.add('hidden');
         this.modal.style.display = 'flex';
     }
 
     update(progress) {
         this.progressBar.style.width = `${progress}%`;
+        this.progressText.textContent = `${progress}%`;
     }
 
     showClose() {
-        this.closeBtn.style.display = 'block';
+        this.progressText.textContent = 'Fertig';
+        this.closeBtn.classList.remove('hidden');
     }
 
     onClose(cb) {

--- a/resources/js/components/ZipDownloader.js
+++ b/resources/js/components/ZipDownloader.js
@@ -53,7 +53,7 @@ export default class ZipDownloader {
             .querySelector('meta[name="csrf-token"]')
             .getAttribute('content');
         const {
-            data: { id }
+            data: { jobId }
         } = await axios.post(
             postUrl,
             { assignment_ids: selected },
@@ -66,12 +66,12 @@ export default class ZipDownloader {
         );
 
         const poll = setInterval(async () => {
-            const { data: r } = await axios.get(`/zips/${id}/progress`);
+            const { data: r } = await axios.get(`/zips/${jobId}/progress`);
             this.modal.update(r.progress || 0);
             if (r.status === 'ready') {
                 clearInterval(poll);
                 const link = document.createElement('a');
-                link.href = `/zips/${id}/download`;
+                link.href = `/zips/${jobId}/download`;
                 document.body.appendChild(link);
                 link.click();
                 link.remove();


### PR DESCRIPTION
## Summary
- poll and fetch downloads using BuildZipJob jobId instead of file id
- add progress text and tidy styles in download modal

## Testing
- `npm test` *(fails: Missing script "test")*
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6899becea0788329aaefeec729761833