### PR TITLE
Add Impressum page and footer link

### DIFF
--- a/resources/views/impressum.blade.php
+++ b/resources/views/impressum.blade.php
@@ -1,0 +1,36 @@
+@extends('layouts.app')
+
+@section('title', 'Impressum')
+
+@section('content')
+    <h1>Impressum</h1>
+
+    <h2>Diensteanbieter</h2>
+    <p>Ilya Beliaev<br>
+        Am Haferberg 5<br>
+        21502 Geesthacht<br>
+        Deutschland
+    </p>
+
+    <h2>Kontaktmöglichkeiten</h2>
+    <p>E-Mail-Adresse: <a href="mailto:info@php-dev.info">info@php-dev.info</a></p>
+
+    <h2>Haftung für Inhalte</h2>
+    <p>Als Diensteanbieter sind wir gemäß § 7 Abs. 1 TMG für eigene Inhalte auf diesen Seiten nach den allgemeinen
+        Gesetzen verantwortlich. Nach §§ 8 bis 10 TMG sind wir jedoch nicht verpflichtet, übermittelte oder gespeicherte
+        fremde Informationen zu überwachen oder nach Umständen zu forschen, die auf eine rechtswidrige Tätigkeit
+        hinweisen. Verpflichtungen zur Entfernung oder Sperrung der Nutzung von Informationen nach den allgemeinen
+        Gesetzen bleiben hiervon unberührt.</p>
+
+    <h2>Haftung für Links</h2>
+    <p>Unser Angebot enthält Links zu externen Websites Dritter, auf deren Inhalte wir keinen Einfluss haben. Deshalb können
+        wir für diese fremden Inhalte auch keine Gewähr übernehmen. Für die Inhalte der verlinkten Seiten ist stets der
+        jeweilige Anbieter oder Betreiber der Seiten verantwortlich. Eine permanente inhaltliche Kontrolle der verlinkten
+        Seiten ist jedoch ohne konkrete Anhaltspunkte einer Rechtsverletzung nicht zumutbar.</p>
+
+    <h2>Urheberrecht</h2>
+    <p>Die durch die Seitenbetreiber erstellten Inhalte und Werke auf diesen Seiten unterliegen dem deutschen Urheberrecht.
+        Die Vervielfältigung, Bearbeitung, Verbreitung und jede Art der Verwertung außerhalb der Grenzen des
+        Urheberrechtes bedürfen der schriftlichen Zustimmung des jeweiligen Autors bzw. Erstellers.</p>
+@endsection
+

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -43,6 +43,7 @@
 <footer>
     &copy; {{ date('Y') }} {{ config('app.name', 'App') }} - Version: <a
             href="{{route('changelog')}}" target="_blank">{{ config('app.version', '0.0.0-dev') }}</a>
+    - <a href="{{ route('impressum') }}">Impressum</a>
 </footer>
 
 @stack('scripts')

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,8 @@ Route::get('/changelog', function () {
     return Str::markdown(file_get_contents(base_path('CHANGELOG.md')));
 })->name('changelog');
 
+Route::view('/impressum', 'impressum')->name('impressum');
+
 
 Route::get('/offer/{batch}/{channel}', [OfferController::class, 'show'])->name('offer.show');
 // ZIP-Download via asynchronen Job


### PR DESCRIPTION
## Summary
- add `/impressum` route
- create Impressum view with provider info and legal disclaimers
- link Impressum page in app layout footer

## Testing
- `composer test` *(fails: Failed opening required '/workspace/video_sharing/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_6899c07a8a088329a3527ac62564c4a8