### PR TITLE
Refine card buttons and light mode chip styling

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -124,6 +124,10 @@
         background: var(--color-btn);
     }
 
+    .btn-sm {
+        @apply px-2 py-1 text-[0.9rem];
+    }
+
     .btn:hover {
         background: var(--color-btn-hover);
         text-decoration: none;
@@ -156,6 +160,10 @@
     .chip {
         @apply inline-block px-[6px] py-[2px] rounded-[6px] border border-border text-text text-[0.9rem];
         background: #2a2f37;
+    }
+
+    .light .chip {
+        background: var(--color-btn-light);
     }
 }
 

--- a/resources/views/offer/show.blade.php
+++ b/resources/views/offer/show.blade.php
@@ -83,8 +83,8 @@
                                     @endforeach
 
                                     <div style="margin-top:10px; display:flex; gap:10px; flex-wrap:wrap;">
-                                        <a class="btn" href="{{ $a->temp_url }}">Einzeln laden</a>
-                                        <button type="button" class="btn"
+                                        <a class="btn btn-sm" href="{{ $a->temp_url }}">Einzeln laden</a>
+                                        <button type="button" class="btn btn-sm"
                                                 onclick="this.closest('.card').querySelector('.inline-preview').style.display='block'">
                                             Vorschau öffnen
                                         </button>


### PR DESCRIPTION
## Summary
- add compact `btn-sm` utility and apply it to card buttons for smaller controls
- adjust chip background in light mode to blend with light theme

## Testing
- `npm run build`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6899c1013fa08329b9da0bb58c9d2bb5