### PR TITLE
Fix zip download when cache stores absolute path

### DIFF
--- a/app/Http/Controllers/ZipController.php
+++ b/app/Http/Controllers/ZipController.php
@@ -65,10 +65,16 @@ class ZipController extends Controller
     {
         $path = $this->cache->getFile($id);
         $name = $this->cache->getName($id, "{$id}.zip");
-        if (!$path || !Storage::exists($path)) {
+
+        if (!$path) {
             abort(404);
         }
 
-        return response()->download(Storage::path($path), $name)->deleteFileAfterSend();
+        $fullPath = Storage::exists($path) ? Storage::path($path) : $path;
+        if (!is_file($fullPath)) {
+            abort(404);
+        }
+
+        return response()->download($fullPath, $name)->deleteFileAfterSend();
     }
 }

--- a/tests/Feature/ZipDownloadTest.php
+++ b/tests/Feature/ZipDownloadTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class ZipDownloadTest extends TestCase
+{
+    public function test_download_succeeds_when_file_exists(): void
+    {
+        Storage::fake();
+
+        $id = 'job1';
+        $path = "zips/{$id}.zip";
+        Storage::put($path, 'dummy');
+        $absolute = Storage::path($path);
+        Cache::put("zipjob:{$id}:file", $absolute, 600);
+        Cache::put("zipjob:{$id}:name", 'download.zip', 600);
+
+        $response = $this->get("/zips/{$id}/download");
+
+        $response->assertOk();
+        $response->assertHeader('content-disposition');
+    }
+}


### PR DESCRIPTION
## Summary
- make ZipController handle absolute paths returned from cache
- add test covering zip downloads using an absolute file path

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6899dfc8e1188329a4b6d613868ccc39