### PR TITLE
fix: ensure zip download uses server filename

### DIFF
--- a/resources/js/components/ZipDownloader.js
+++ b/resources/js/components/ZipDownloader.js
@@ -72,19 +72,20 @@ export default class ZipDownloader {
             if (r.status === 'ready' && !downloading) {
                 downloading = true;
                 clearInterval(poll);
-                await this.downloadZip(jobId);
+                await this.downloadZip(jobId, r.name);
             }
         }, 500);
     }
 
-    async downloadZip(jobId) {
+    async downloadZip(jobId, filename) {
         const response = await axios.get(`/zips/${jobId}/download`, {
             responseType: 'blob'
         });
-        const url = window.URL.createObjectURL(new Blob([response.data]));
+        const blob = new Blob([response.data], { type: 'application/zip' });
+        const url = window.URL.createObjectURL(blob);
         const link = document.createElement('a');
         link.href = url;
-        link.setAttribute('download', '');
+        link.setAttribute('download', filename || `download-${jobId}.zip`);
         document.body.appendChild(link);
         link.click();
         link.remove();


### PR DESCRIPTION
## Summary
- use filename from progress response when ready to set ZIP download name

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `composer test` *(fails: Failed opening required '/workspace/video_sharing/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_6899ea3b3f34832989d3f920f5f3316b