### PR TITLE
Switch ZIP download progress to WebSockets

### DIFF
--- a/app/Events/ZipProgressUpdated.php
+++ b/app/Events/ZipProgressUpdated.php
@@ -6,17 +6,19 @@ namespace App\Events;
 
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PrivateChannel;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class ZipProgressUpdated implements ShouldBroadcast
+class ZipProgressUpdated implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
     public function __construct(
         public string $jobId,
-        public array $state
+        public string $status,
+        public int $progress,
+        public ?string $name = null,
     ) {
     }
 
@@ -32,6 +34,10 @@ class ZipProgressUpdated implements ShouldBroadcast
 
     public function broadcastWith(): array
     {
-        return $this->state;
+        return [
+            'status' => $this->status,
+            'progress' => $this->progress,
+            'name' => $this->name,
+        ];
     }
 }

--- a/app/Services/ZipService.php
+++ b/app/Services/ZipService.php
@@ -245,9 +245,10 @@ class ZipService
             Storage::delete($file);
         }
 
-        $this->cache->setStatus($jobId, DownloadStatusEnum::READY->value);
         $this->cache->setFile($jobId, $tmpPath);
         $this->cache->setName($jobId, $downloadName);
+        $this->cache->setProgress($jobId, 100);
+        $this->cache->setStatus($jobId, DownloadStatusEnum::READY->value);
     }
 
 }

--- a/resources/js/components/ZipDownloader.js
+++ b/resources/js/components/ZipDownloader.js
@@ -66,16 +66,16 @@ export default class ZipDownloader {
         );
 
         let downloading = false;
-        const poll = setInterval(async () => {
-            const { data: r } = await axios.get(`/zips/${jobId}/progress`);
+        const channelName = `zip.${jobId}`;
+        window.Echo.private(channelName).listen('.zip.progress', async r => {
             if (r.status === 'ready' && !downloading) {
                 downloading = true;
-                clearInterval(poll);
                 await this.downloadZip(jobId, r.name);
+                window.Echo.leave(channelName);
             } else {
                 this.modal.update(r.progress || 0, r.status);
             }
-        }, 500);
+        });
     }
 
     async downloadZip(jobId, filename) {


### PR DESCRIPTION
## Summary
- broadcast ZIP creation updates via `ZipProgressUpdated` event
- push cache status changes over WebSockets
- listen for `zip.progress` in frontend instead of polling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689a1664543c83298f1bb69779feb391