### PR TITLE
Respect markdown line breaks when rendering pages

### DIFF
--- a/app/Services/PageService.php
+++ b/app/Services/PageService.php
@@ -14,7 +14,9 @@ class PageService
     {
         $page = Page::query()->where('slug', $slug)->first();
 
-        return $page ? Str::markdown($page->content) : null;
+        return $page ? Str::markdown($page->content, [
+            'renderer' => ['soft_break' => "<br />"],
+        ]) : null;
     }
 
     public function getPagesForSection(string $section): Collection


### PR DESCRIPTION
## Summary
- ensure page content converts Markdown line breaks to `<br>` during HTML rendering

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_689a3ed5f2608329bd0452143b5bc514