### PR TITLE
Highlight GitHub footer link with heart

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -46,8 +46,7 @@
     - <a href="{{ route('impressum') }}" target="_blank">Impressum</a>
     - <a href="{{ route('datenschutz') }}" target="_blank">Datenschutz</a>
     <br/>
-    <a href="https://github.com/N3XT0R/dashclip-delivery" style="color: #64748b; text-decoration: none;">Developed with
-        love</a>
+    <a href="https://github.com/N3XT0R/dashclip-delivery" target="_blank">❤️ GitHub</a>
 </footer>
 
 @stack('scripts')


### PR DESCRIPTION
## Summary
- Show GitHub link in the footer with a heart emoji and visible link styling

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689a50421cb48329a5cc6a8acb4f7bad