### PR TITLE
docs: add supervisor config example

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -143,3 +143,29 @@ Crontab einrichten:
 ```bash
 * * * * * cd /var/www/mydomain.de/htdocs/current/ && php artisan schedule:run >> /dev/null 2>&1
 ```
+
+## Supervisor für Queue-Worker
+
+Für das dauerhafte Ausführen von `queue:work` kann Supervisor verwendet werden.
+Beispielkonfiguration in `/etc/supervisor/conf.d/laravel-worker.conf`:
+
+```ini
+[program:laravel-worker]
+process_name=%(program_name)s_%(process_num)02d
+command=php /var/www/dashclip/artisan queue:work --sleep=3 --tries=3
+autostart=true
+autorestart=true
+user=www-data
+numprocs=1
+redirect_stderr=true
+stdout_logfile=/var/log/supervisor/laravel-worker.log
+stopwaitsecs=3600
+```
+
+Supervisor neu laden und den Worker starten:
+
+```bash
+sudo supervisorctl reread
+sudo supervisorctl update
+sudo supervisorctl start laravel-worker:*
+```


### PR DESCRIPTION
## Summary
- document example Supervisor configuration for `queue:work`

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689a566aca748329b0745105f915d80a