### PR TITLE
Add unit and integration tests for services

### DIFF
--- a/tests/Feature/LinkServiceTest.php
+++ b/tests/Feature/LinkServiceTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Batch;
+use App\Models\Channel;
+use App\Services\LinkService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LinkServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_offer_url_allows_access_with_valid_signature(): void
+    {
+        $batch = Batch::create(['type' => 'assign']);
+        $channel = Channel::create([
+            'name' => 'TestChannel',
+            'creator_name' => null,
+            'email' => 'testchannel@example.com',
+            'weight' => 1,
+            'weekly_quota' => 5,
+        ]);
+
+        $service = new LinkService();
+        $url = $service->getOfferUrl($batch, $channel, now()->addMinutes(5));
+
+        $response = $this->get($url);
+
+        $response->assertStatus(200);
+    }
+}

--- a/tests/Feature/PageServiceTest.php
+++ b/tests/Feature/PageServiceTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Page;
+use App\Services\PageService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PageServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_get_html_returns_rendered_markdown(): void
+    {
+        Page::create([
+            'slug' => 'terms',
+            'title' => 'Terms',
+            'section' => 'docs',
+            'content' => "# Hello\n\nThis is **markdown**.",
+        ]);
+
+        $service = new PageService();
+        $html = $service->getHtml('terms');
+
+        $this->assertNotNull($html);
+        $this->assertStringContainsString('<h1>Hello</h1>', $html);
+        $this->assertStringContainsString('<strong>markdown</strong>', $html);
+    }
+
+    public function test_get_pages_for_section_returns_collection(): void
+    {
+        Page::create([
+            'slug' => 'about',
+            'title' => 'About',
+            'section' => 'about-section',
+            'content' => 'Content',
+        ]);
+
+        $service = new PageService();
+        $pages = $service->getPagesForSection('about-section');
+
+        $this->assertCount(1, $pages);
+        $this->assertSame('about', $pages->first()->slug);
+    }
+}

--- a/tests/Unit/LinkServiceTest.php
+++ b/tests/Unit/LinkServiceTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Batch;
+use App\Models\Channel;
+use App\Services\LinkService;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\URL;
+use Tests\TestCase;
+
+class LinkServiceTest extends TestCase
+{
+    public function test_get_offer_url_uses_signed_route(): void
+    {
+        $batch = new Batch();
+        $batch->id = 10;
+        $channel = new Channel();
+        $channel->id = 5;
+        $expire = Carbon::now()->addMinutes(5);
+
+        URL::shouldReceive('temporarySignedRoute')
+            ->once()
+            ->with('offer.show', $expire, ['batch' => 10, 'channel' => 5])
+            ->andReturn('signed-offer-url');
+
+        $service = new LinkService();
+        $url = $service->getOfferUrl($batch, $channel, $expire);
+
+        $this->assertSame('signed-offer-url', $url);
+    }
+
+    public function test_get_unused_url_uses_signed_route(): void
+    {
+        $batch = new Batch();
+        $batch->id = 12;
+        $channel = new Channel();
+        $channel->id = 3;
+        $expire = Carbon::now()->addMinutes(5);
+
+        URL::shouldReceive('temporarySignedRoute')
+            ->once()
+            ->with('offer.unused.show', $expire, ['batch' => 12, 'channel' => 3])
+            ->andReturn('signed-unused-url');
+
+        $service = new LinkService();
+        $url = $service->getUnusedUrl($batch, $channel, $expire);
+
+        $this->assertSame('signed-unused-url', $url);
+    }
+
+    public function test_get_store_unused_url_uses_signed_route(): void
+    {
+        $batch = new Batch();
+        $batch->id = 7;
+        $channel = new Channel();
+        $channel->id = 2;
+        $expire = Carbon::now()->addMinutes(5);
+
+        URL::shouldReceive('temporarySignedRoute')
+            ->once()
+            ->with('offer.unused.store', $expire, ['batch' => 7, 'channel' => 2])
+            ->andReturn('signed-store-unused-url');
+
+        $service = new LinkService();
+        $url = $service->getStoreUnusedUrl($batch, $channel, $expire);
+
+        $this->assertSame('signed-store-unused-url', $url);
+    }
+
+    public function test_get_zip_selected_url_uses_signed_route(): void
+    {
+        $batch = new Batch();
+        $batch->id = 15;
+        $channel = new Channel();
+        $channel->id = 9;
+        $expire = Carbon::now()->addMinutes(5);
+
+        URL::shouldReceive('temporarySignedRoute')
+            ->once()
+            ->with('zips.start', $expire, ['batch' => 15, 'channel' => 9])
+            ->andReturn('signed-zip-url');
+
+        $service = new LinkService();
+        $url = $service->getZipSelectedUrl($batch, $channel, $expire);
+
+        $this->assertSame('signed-zip-url', $url);
+    }
+}


### PR DESCRIPTION
## Summary
- cover LinkService with unit tests for each generated URL
- add integration test for LinkService verifying signed offer URL
- add integration tests for PageService markdown rendering and section queries

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_689a57f7e67c83299b19deb7227b385d