### PR TITLE
Add integration tests for Filament resources

### DIFF
--- a/tests/Integration/Filament/AssignmentResourceTest.php
+++ b/tests/Integration/Filament/AssignmentResourceTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Filament;
+
+use App\Filament\Resources\AssignmentResource;
+use App\Filament\Resources\AssignmentResource\Pages\ListAssignments;
+use App\Models\Assignment;
+use App\Models\Batch;
+use App\Models\Channel;
+use Carbon\Carbon;
+use Filament\Tables\Table;
+use Illuminate\Support\Facades\URL;
+use Tests\DatabaseTestCase;
+
+class AssignmentResourceTest extends DatabaseTestCase
+{
+    public function test_offer_action_generates_signed_url(): void
+    {
+        Carbon::setTestNow('2024-01-01 00:00:00');
+
+        $batch = Batch::factory()->type('assign')->create();
+        $channel = Channel::factory()->create();
+        $assignment = Assignment::factory()
+            ->for($channel)
+            ->withBatch($batch)
+            ->create();
+
+        $page = app(ListAssignments::class);
+        $table = AssignmentResource::table(Table::make($page));
+
+        $action = $table->getFlatActions()['offer'];
+        $action->record($assignment);
+
+        $url = $action->getUrl();
+        $expected = URL::temporarySignedRoute(
+            'offer.show',
+            Carbon::now()->addDay(),
+            ['batch' => $batch->id, 'channel' => $channel->id]
+        );
+
+        $this->assertSame($expected, $url);
+
+        Carbon::setTestNow();
+    }
+}

--- a/tests/Integration/Filament/AssignmentsPageTest.php
+++ b/tests/Integration/Filament/AssignmentsPageTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Filament;
+
+use App\Filament\Pages\Assignments;
+use App\Models\Assignment;
+use App\Models\Batch;
+use App\Models\Channel;
+use Carbon\Carbon;
+use Filament\Tables\Table;
+use Illuminate\Support\Facades\URL;
+use Tests\DatabaseTestCase;
+
+class AssignmentsPageTest extends DatabaseTestCase
+{
+    public function test_offer_url_column_generates_signed_url(): void
+    {
+        Carbon::setTestNow('2024-01-01 00:00:00');
+
+        $batch = Batch::factory()->type('assign')->create();
+        $channel = Channel::factory()->create();
+        $assignment = Assignment::factory()
+            ->for($channel)
+            ->withBatch($batch)
+            ->create();
+
+        $page = app(Assignments::class);
+        $table = $page->table(Table::make($page));
+
+        $column = $table->getColumn('offer_url');
+        $column->record($assignment);
+
+        $url = $column->getUrl();
+        $expected = URL::temporarySignedRoute(
+            'offer.show',
+            Carbon::now()->addYears(10),
+            ['batch' => $batch->id, 'channel' => $channel->id]
+        );
+
+        $this->assertSame($expected, $url);
+
+        Carbon::setTestNow();
+    }
+}

--- a/tests/Integration/Filament/ChannelResourceTest.php
+++ b/tests/Integration/Filament/ChannelResourceTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Filament;
+
+use App\Filament\Resources\ChannelResource;
+use App\Filament\Resources\ChannelResource\Pages\ListChannels;
+use Filament\Tables\Table;
+use Tests\TestCase;
+
+class ChannelResourceTest extends TestCase
+{
+    public function test_name_column_is_searchable(): void
+    {
+        $page = app(ListChannels::class);
+        $table = ChannelResource::table(Table::make($page));
+
+        $column = $table->getColumn('name');
+
+        $this->assertTrue($column->isSearchable());
+    }
+}


### PR DESCRIPTION
## Summary
- add integration test for Assignment resource offer action
- add integration test for Assignments page offer URL column
- ensure Channel resource table name column is searchable

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_689ba63d5a788329bc54712f1bce8ee1