### PR TITLE
Add Config management tab with visibility flag

### DIFF
--- a/app/Filament/Resources/ConfigResource.php
+++ b/app/Filament/Resources/ConfigResource.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\ConfigResource\Pages;
+use App\Models\Config;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class ConfigResource extends Resource
+{
+    protected static ?string $model = Config::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-cog-6-tooth';
+    protected static ?string $navigationGroup = 'Settings';
+    protected static ?string $modelLabel = 'Config';
+    protected static ?string $pluralModelLabel = 'Configs';
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([
+            Forms\Components\TextInput::make('key')
+                ->required()
+                ->maxLength(255)
+                ->disabled(),
+            Forms\Components\Textarea::make('value')
+                ->label('Value')
+                ->required()
+                ->columnSpanFull(),
+            Forms\Components\Toggle::make('is_visible')
+                ->label('Visible')
+                ->required(),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('key')
+                    ->sortable()
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('value')
+                    ->limit(50)
+                    ->searchable(),
+                Tables\Columns\IconColumn::make('is_visible')
+                    ->boolean()
+                    ->label('Visible'),
+            ])
+            ->filters([
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListConfigs::route('/'),
+            'edit' => Pages\EditConfig::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/ConfigResource/Pages/EditConfig.php
+++ b/app/Filament/Resources/ConfigResource/Pages/EditConfig.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Filament\Resources\ConfigResource\Pages;
+
+use App\Filament\Resources\ConfigResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditConfig extends EditRecord
+{
+    protected static string $resource = ConfigResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/app/Filament/Resources/ConfigResource/Pages/ListConfigs.php
+++ b/app/Filament/Resources/ConfigResource/Pages/ListConfigs.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Filament\Resources\ConfigResource\Pages;
+
+use App\Filament\Resources\ConfigResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListConfigs extends ListRecords
+{
+    protected static string $resource = ConfigResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/app/Models/Config.php
+++ b/app/Models/Config.php
@@ -11,5 +11,5 @@ class Config extends Model
 {
     use HasFactory;
     
-    protected $fillable = ['key', 'value'];
+    protected $fillable = ['key', 'value', 'is_visible'];
 }

--- a/database/factories/ConfigFactory.php
+++ b/database/factories/ConfigFactory.php
@@ -33,6 +33,7 @@ class ConfigFactory extends Factory
                 'feature.flags' => json_encode(['realtimeZip' => true]),
                 default => $this->faker->sentence(),
             },
+            'is_visible' => true,
         ];
     }
 

--- a/database/migrations/2025_08_12_000000_add_is_visible_to_configs_table.php
+++ b/database/migrations/2025_08_12_000000_add_is_visible_to_configs_table.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('configs', function (Blueprint $table) {
+            $table->boolean('is_visible')->default(true);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('configs', function (Blueprint $table) {
+            $table->dropColumn('is_visible');
+        });
+    }
+};

--- a/tests/Integration/Filament/Resources/ConfigResourceTest.php
+++ b/tests/Integration/Filament/Resources/ConfigResourceTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Filament\Resources;
+
+use App\Filament\Resources\ConfigResource\Pages\EditConfig;
+use App\Filament\Resources\ConfigResource\Pages\ListConfigs;
+use App\Models\Config;
+use App\Models\User;
+use Livewire\Livewire;
+use Tests\DatabaseTestCase;
+
+/**
+ * Integration tests for the Filament ConfigResource.
+ *
+ * We verify:
+ *  - ListConfigs renders and shows records
+ *  - EditConfig loads a record, validates required fields, and persists changes
+ */
+final class ConfigResourceTest extends DatabaseTestCase
+{
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Authenticate as a user (User::canAccessPanel returns true)
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
+    }
+
+    public function testListConfigsShowsExistingRecords(): void
+    {
+        Config::query()->create([
+            'key' => 'site.name',
+            'value' => 'Dashclip',
+            'is_visible' => true,
+        ]);
+
+        Config::query()->create([
+            'key' => 'ui.theme',
+            'value' => 'light',
+            'is_visible' => false,
+        ]);
+
+        Livewire::test(ListConfigs::class)
+            ->assertStatus(200)
+            ->assertSee('site.name')
+            ->assertSee('ui.theme');
+    }
+
+    public function testEditConfigValidatesAndUpdatesFields(): void
+    {
+        $config = Config::query()->create([
+            'key' => 'site.locale',
+            'value' => 'de',
+            'is_visible' => true,
+        ]);
+
+        Livewire::test(EditConfig::class, ['record' => $config->getKey()])
+            ->assertStatus(200)
+            ->assertFormSet([
+                'key' => 'site.locale',
+                'value' => 'de',
+                'is_visible' => true,
+            ])
+            ->fillForm([
+                'value' => '',
+                'is_visible' => false,
+            ])
+            ->call('save')
+            ->assertHasFormErrors(['value' => 'required']);
+
+        Livewire::test(EditConfig::class, ['record' => $config->getKey()])
+            ->fillForm([
+                'value' => 'en',
+                'is_visible' => false,
+            ])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $fresh = $config->fresh();
+        $this->assertSame('site.locale', $fresh->getAttribute('key'));
+        $this->assertSame('en', $fresh->getAttribute('value'));
+        $this->assertFalse((bool) $fresh->getAttribute('is_visible'));
+    }
+}

--- a/tests/Unit/Models/ConfigTest.php
+++ b/tests/Unit/Models/ConfigTest.php
@@ -24,11 +24,13 @@ final class ConfigTest extends DatabaseTestCase
         $cfg = Config::query()->create([
             'key' => 'dropbox_refresh_token',
             'value' => 'rt_abc123',
+            'is_visible' => false,
         ])->fresh();
 
         // Assert
         $this->assertSame('dropbox_refresh_token', $cfg->getAttribute('key'));
         $this->assertSame('rt_abc123', $cfg->getAttribute('value'));
+        $this->assertFalse((bool) $cfg->getAttribute('is_visible'));
     }
 
     public function testUniqueKeyConstraintPreventsDuplicates(): void


### PR DESCRIPTION
## Summary
- add `is_visible` column to `configs` table
- introduce Filament ConfigResource to list and edit configs without creating new entries
- cover configuration editing with integration tests

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689c6bfae30c8329bb72455efe507e18