### PR TITLE
Notify on invalid config values

### DIFF
--- a/app/Filament/Resources/ConfigResource/Pages/EditConfig.php
+++ b/app/Filament/Resources/ConfigResource/Pages/EditConfig.php
@@ -4,6 +4,9 @@ namespace App\Filament\Resources\ConfigResource\Pages;
 
 use App\Filament\Resources\ConfigResource;
 use Filament\Resources\Pages\EditRecord;
+use Filament\Notifications\Notification;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Validation\ValidationException;
 
 class EditConfig extends EditRecord
 {
@@ -12,5 +15,25 @@ class EditConfig extends EditRecord
     protected function getHeaderActions(): array
     {
         return [];
+    }
+
+    /**
+     * Provide user feedback when a config value fails to save.
+     */
+    protected function handleRecordUpdate(Model $record, array $data): Model
+    {
+        try {
+            $record->update($data);
+        } catch (ValidationException $exception) {
+            Notification::make()
+                ->title('Speichern fehlgeschlagen')
+                ->body('Die Konfiguration konnte nicht gespeichert werden. Bitte prüfen Sie Ihre Eingaben.')
+                ->danger()
+                ->send();
+
+            throw $exception;
+        }
+
+        return $record;
     }
 }


### PR DESCRIPTION
## Summary
- show notification on EditConfig page when configuration value fails validation

## Testing
- `composer test` *(fails: No code coverage driver with path coverage support available, but tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_689ca84253a08329b581457423f080a6