### PR TITLE
docs: update README for current master

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 [![Maintainability](https://qlty.sh/gh/N3XT0R/projects/dashclip-delivery/maintainability.svg)](https://qlty.sh/gh/N3XT0R/projects/dashclip-delivery)
 [![Code Coverage](https://qlty.sh/gh/N3XT0R/projects/dashclip-delivery/coverage.svg)](https://qlty.sh/gh/N3XT0R/projects/dashclip-delivery)
 
-# Video Sharing Plattform
+# Dashclip-Delivery
 
 ## Projektbeschreibung
 
-Dieses Projekt ist eine Laravel‑Anwendung zum Verteilen von Videomaterial an verschiedene Kanäle. Neue Videos werden aus
+Dashclip-Delivery ist eine Laravel‑Anwendung zum Verteilen von Videomaterial an verschiedene Kanäle. Neue Videos werden aus
 einem Upload‑Verzeichnis oder aus Dropbox eingelesen, auf einem konfigurierten Storage gespeichert und anschließend fair
 auf Kanäle mit Quoten und Gewichtung verteilt. Die Kanäle erhalten per E‑Mail signierte Links zu einer Angebotsseite,
 auf der sie einzelne Videos oder eine ZIP‑Datei mit begleitender `info.csv` herunterladen können. Nicht benötigte Videos
@@ -50,7 +50,7 @@ php artisan migrate
 | `php artisan assign:distribute` | Verteilt Videos auf Kanäle.                                     |
 | `php artisan notify:offers`     | Versendet Angebotslinks per E‑Mail.                             |
 | `php artisan assign:expire`     | Markiert abgelaufene Zuweisungen und blockiert Kanäle temporär. |
-| `php artisan previews:generate` | Erzeugt Vorschau‑Clips.                                         |
+| `php artisan dropbox:refresh-token` | Aktualisiert den Dropbox Token.                             |
 | `php artisan weekly:run`        | Führt Expire → Distribute → Notify hintereinander aus.          |
 
 ## Dokumentation


### PR DESCRIPTION
## Summary
- rename heading to Dashclip-Delivery
- document dropbox token refresh command and drop previews generator

## Testing
- `composer test` *(fails: Script @php artisan test handling the test event returned with error code 1)*

------
https://chatgpt.com/codex/tasks/task_e_689ce81ff4d48329b1106ffc77209d92