### PR TITLE
feat(schedule): load cron jobs from config

### DIFF
--- a/app/Console/Commands/AssignExpire.php
+++ b/app/Console/Commands/AssignExpire.php
@@ -23,7 +23,7 @@ class AssignExpire extends Command
     {
         $cooldownDays = (int)$this->option('cooldown-days');
         if (0 === $cooldownDays) {
-            $cooldownDays = (int)Cfg::get('assign_expire_cooldown_days', 14);
+            $cooldownDays = (int)Cfg::get('assign_expire_cooldown_days', null, 14);
         }
         $expiredCount = $this->expirer->expire($cooldownDays);
         $this->info("Expired: {$expiredCount}");

--- a/app/Facades/Cfg.php
+++ b/app/Facades/Cfg.php
@@ -8,8 +8,9 @@ use App\Services\Contracts\ConfigServiceInterface;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @method static mixed get(string $key, mixed $default = null)
+ * @method static mixed get(string $key, ?string $category = null, mixed $default = null)
  * @method static bool has(string $key)
+ * @method static \App\Models\Config set(string $key, mixed $value, ?string $category = null, array $subSettings = [], string $castType = 'string', bool $isVisible = true)
  */
 class Cfg extends Facade
 {

--- a/app/Models/Config.php
+++ b/app/Models/Config.php
@@ -8,17 +8,31 @@ use App\Support\ConfigCaster;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\Validator;
+use App\Models\ConfigCategory;
+use App\Models\ConfigSubSetting;
 
 class Config extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['key', 'value', 'is_visible', 'cast_type'];
+    protected $fillable = ['key', 'value', 'is_visible', 'cast_type', 'config_category_id'];
 
     protected $casts = [
         'is_visible' => 'bool',
     ];
+
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(ConfigCategory::class, 'config_category_id');
+    }
+
+    public function subSettings(): HasMany
+    {
+        return $this->hasMany(ConfigSubSetting::class);
+    }
 
     /**
      * Cast the "value" attribute according to the "cast_type" column.

--- a/app/Models/ConfigCategory.php
+++ b/app/Models/ConfigCategory.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class ConfigCategory extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['key'];
+
+    public function configs(): HasMany
+    {
+        return $this->hasMany(Config::class);
+    }
+}

--- a/app/Models/ConfigSubSetting.php
+++ b/app/Models/ConfigSubSetting.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Support\ConfigCaster;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Validator;
+
+class ConfigSubSetting extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['config_id', 'key', 'value', 'cast_type'];
+
+    public function config(): BelongsTo
+    {
+        return $this->belongsTo(Config::class);
+    }
+
+    protected function value(): Attribute
+    {
+        return Attribute::make(
+            get: fn($value, array $attributes) => ConfigCaster::toPhp($attributes['cast_type'] ?? 'string', $value),
+            set: fn($value) => $value,
+        );
+    }
+
+    protected static function booted(): void
+    {
+        static::saving(function (ConfigSubSetting $setting): void {
+            $type = $setting->cast_type ?? 'string';
+            $raw = $setting->attributes['value'] ?? null;
+            Validator::make(
+                ['value' => $raw],
+                ['value' => ConfigCaster::rule($type, $raw)]
+            )->validate();
+            $setting->attributes['value'] = ConfigCaster::toStorage($type, $raw);
+        });
+    }
+}

--- a/app/Services/AssignmentService.php
+++ b/app/Services/AssignmentService.php
@@ -84,7 +84,7 @@ class AssignmentService
     public function prepareDownload(Assignment $assignment, ?int $ttlHours = null, bool $skipTracking = false): string
     {
         if (null === $ttlHours) {
-            $ttlHours = Cfg::get('download_ttl_hours', 144);
+            $ttlHours = Cfg::get('download_ttl_hours', null, 144);
         }
 
 

--- a/app/Services/ConfigService.php
+++ b/app/Services/ConfigService.php
@@ -5,22 +5,123 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\Models\Config;
+use App\Models\ConfigCategory;
 use App\Services\Contracts\ConfigServiceInterface;
+use Illuminate\Support\Facades\Cache;
 
 class ConfigService implements ConfigServiceInterface
 {
-    public function get(string $key, mixed $default = null): mixed
+    public function get(string $key, ?string $category = null, mixed $default = null): mixed
     {
-        return rescue(
-            fn() => Config::query()->where('key', $key)->first()?->value ?? $default,
-            $default
-        );
+        [$cfgKey, $subKey] = explode('.', $key, 2) + [1 => null];
+
+        $slug = $category ?? 'default';
+        $cacheKey = $this->cacheKey($slug, $cfgKey, $subKey);
+
+        if (Cache::has($cacheKey)) {
+            return Cache::get($cacheKey);
+        }
+
+        return rescue(function () use ($cfgKey, $subKey, $slug, $default) {
+            $query = Config::query()
+                ->with(['subSettings', 'category'])
+                ->where('key', $cfgKey);
+
+            if ($slug === 'default') {
+                $query->where(function ($q) {
+                    $q->whereNull('config_category_id')
+                        ->orWhereHas('category', fn($q) => $q->where('key', 'default'));
+                });
+            } else {
+                $query->whereHas('category', fn($q) => $q->where('key', $slug));
+            }
+
+            $config = $query->first();
+
+            if (!$config) {
+                return $default;
+            }
+
+            $subValues = $this->rememberConfig($config);
+
+            return $subKey ? ($subValues[$subKey] ?? $default) : ($config->value ?? $default);
+        }, $default);
     }
 
     public function has(string $key): bool
     {
-        return Config::query()->where('key', $key)->exists();
+        return $this->get($key) !== null;
     }
 
+    public function set(
+        string $key,
+        mixed $value,
+        ?string $category = null,
+        array $subSettings = [],
+        string $castType = 'string',
+        bool $isVisible = true,
+    ): Config {
+        $slug = $category ?? 'default';
+        $categoryModel = ConfigCategory::firstOrCreate(['key' => $slug]);
 
+        $config = Config::updateOrCreate(
+            ['key' => $key],
+            [
+                'value' => $value,
+                'cast_type' => $castType,
+                'is_visible' => $isVisible,
+                'config_category_id' => $categoryModel->id,
+            ],
+        );
+
+        foreach ($subSettings as $subKey => $data) {
+            $config->subSettings()->updateOrCreate(
+                ['key' => $subKey],
+                [
+                    'value' => $data['value'] ?? null,
+                    'cast_type' => $data['cast_type'] ?? 'string',
+                ],
+            );
+        }
+
+        Cache::forget("configs::map::{$config->key}");
+        Cache::forget($this->cacheKey($slug, $config->key, null));
+
+        $config->load('subSettings');
+        foreach ($config->subSettings as $sub) {
+            Cache::forget($this->cacheKey($slug, $config->key, $sub->key));
+        }
+
+        $config->load('category', 'subSettings');
+        $this->rememberConfig($config);
+
+        return $config;
+    }
+
+    /**
+     * Cache the given config and its sub settings.
+     *
+     * @return array<string, mixed> cached sub-setting values
+     */
+    public function rememberConfig(Config $config): array
+    {
+        $slug = $config->category?->key ?? 'default';
+
+        Cache::forever("configs::map::{$config->key}", $slug);
+        Cache::forever($this->cacheKey($slug, $config->key, null), $config->value);
+
+        $subValues = [];
+        foreach ($config->subSettings as $sub) {
+            Cache::forever($this->cacheKey($slug, $config->key, $sub->key), $sub->value);
+            $subValues[$sub->key] = $sub->value;
+        }
+
+        return $subValues;
+    }
+
+    private function cacheKey(string $slug, string $configKey, ?string $subKey): string
+    {
+        $base = "configs::{$slug}::{$configKey}";
+        return $subKey ? "{$base}::{$subKey}" : $base;
+    }
 }

--- a/app/Services/Contracts/ConfigServiceInterface.php
+++ b/app/Services/Contracts/ConfigServiceInterface.php
@@ -4,9 +4,27 @@ declare(strict_types=1);
 
 namespace App\Services\Contracts;
 
+use App\Models\Config;
+
 interface ConfigServiceInterface
 {
-    public function get(string $key, mixed $default = null): mixed;
+    public function get(string $key, ?string $category = null, mixed $default = null): mixed;
 
     public function has(string $key): bool;
+
+    public function set(
+        string $key,
+        mixed $value,
+        ?string $category = null,
+        array $subSettings = [],
+        string $castType = 'string',
+        bool $isVisible = true,
+    ): Config;
+
+    /**
+     * Remember a config and its sub-settings in the cache and return sub values.
+     *
+     * @return array<string, mixed>
+     */
+    public function rememberConfig(Config $config): array;
 }

--- a/app/Services/Schedule/ScheduleConfigFactory.php
+++ b/app/Services/Schedule/ScheduleConfigFactory.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Schedule;
+
+use App\Models\Config;
+use App\Services\ConfigService;
+use Illuminate\Console\Scheduling\Event;
+use Illuminate\Console\Scheduling\Schedule;
+
+class ScheduleConfigFactory
+{
+    public function __construct(private ConfigService $configService)
+    {
+    }
+
+    /**
+     * Register schedule events for all configs within the "schedule" category.
+     */
+    public function register(Schedule $schedule): void
+    {
+        Config::query()
+            ->whereHas('category', fn($q) => $q->where('key', 'schedule'))
+            ->with(['subSettings', 'category'])
+            ->get()
+            ->each(fn(Config $config) => $this->make($schedule, $config));
+    }
+
+    /**
+     * Build a schedule event from the given config.
+     */
+    public function make(Schedule $schedule, Config $config): ?Event
+    {
+        if (!$config->value) {
+            return null;
+        }
+
+        $subs = $this->configService->rememberConfig($config);
+        $params = $subs['params'] ?? [];
+        if (!is_array($params)) {
+            $params = [];
+        }
+
+        $event = $schedule->command($config->key, $params);
+
+        if (!empty($subs['frequency'])) {
+            $event->cron($subs['frequency']);
+        }
+
+        if (!empty($subs['email_on_failure'])) {
+            $event->emailOutputOnFailure($subs['email_on_failure']);
+        }
+
+        if (!empty($subs['environments'])) {
+            $event->environments((array)$subs['environments']);
+        }
+
+        if (!empty($subs['without_overlapping']) && $subs['without_overlapping']) {
+            $event->withoutOverlapping();
+        }
+
+        return $event;
+    }
+}
+

--- a/database/migrations/2025_08_14_000000_create_config_categories_table.php
+++ b/database/migrations/2025_08_14_000000_create_config_categories_table.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('config_categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('config_categories');
+    }
+};

--- a/database/migrations/2025_08_14_010000_add_config_category_id_to_configs_table.php
+++ b/database/migrations/2025_08_14_010000_add_config_category_id_to_configs_table.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('configs', function (Blueprint $table) {
+            $table->foreignId('config_category_id')->nullable()->constrained('config_categories');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('configs', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('config_category_id');
+        });
+    }
+};

--- a/database/migrations/2025_08_14_020000_create_config_sub_settings_table.php
+++ b/database/migrations/2025_08_14_020000_create_config_sub_settings_table.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('config_sub_settings', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('config_id')->constrained()->cascadeOnDelete();
+            $table->string('key', 255);
+            $table->text('value')->nullable();
+            $table->string('cast_type', 255)->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('config_sub_settings');
+    }
+};

--- a/database/migrations/2025_08_14_030000_insert_config_categories_and_ingest_scan.php
+++ b/database/migrations/2025_08_14_030000_insert_config_categories_and_ingest_scan.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+use Carbon\Carbon;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        $timestamp = Carbon::now()->format('Y-m-d H:i:s');
+
+        $categories = collect(['default', 'schedule', 'oauth', 'email'])->map(fn($key) => [
+            'key' => $key,
+            'created_at' => $timestamp,
+            'updated_at' => $timestamp,
+        ])->all();
+
+        DB::table('config_categories')->insert($categories);
+
+        $scheduleId = DB::table('config_categories')->where('key', 'schedule')->value('id');
+
+        $configId = DB::table('configs')->insertGetId([
+            'key' => 'ingest:scan',
+            'value' => '1',
+            'cast_type' => 'bool',
+            'is_visible' => 1,
+            'config_category_id' => $scheduleId,
+            'created_at' => $timestamp,
+            'updated_at' => $timestamp,
+        ]);
+
+        DB::table('config_sub_settings')->insert([
+            [
+                'config_id' => $configId,
+                'key' => 'params',
+                'value' => json_encode(['--inbox' => '/srv/ingest/pending/']),
+                'cast_type' => 'json',
+                'created_at' => $timestamp,
+                'updated_at' => $timestamp,
+            ],
+            [
+                'config_id' => $configId,
+                'key' => 'frequency',
+                'value' => '0 * * * *',
+                'cast_type' => 'string',
+                'created_at' => $timestamp,
+                'updated_at' => $timestamp,
+            ],
+            [
+                'config_id' => $configId,
+                'key' => 'email_on_failure',
+                'value' => 'info@example.tld',
+                'cast_type' => 'string',
+                'created_at' => $timestamp,
+                'updated_at' => $timestamp,
+            ],
+            [
+                'config_id' => $configId,
+                'key' => 'without_overlapping',
+                'value' => '1',
+                'cast_type' => 'bool',
+                'created_at' => $timestamp,
+                'updated_at' => $timestamp,
+            ],
+        ]);
+    }
+
+    public function down(): void
+    {
+        $configId = DB::table('configs')->where('key', 'ingest:scan')->value('id');
+        DB::table('config_sub_settings')->where('config_id', $configId)->delete();
+        DB::table('configs')->where('id', $configId)->delete();
+        DB::table('config_categories')->whereIn('key', ['default', 'schedule', 'oauth', 'email'])->delete();
+    }
+};
+

--- a/resources/views/emails/new-offer.blade.php
+++ b/resources/views/emails/new-offer.blade.php
@@ -75,7 +75,7 @@
 
             <p style="margin:0 0 24px 0;">
                 Viele Grüße<br>
-                {{ config('app.name') }} {{Cfg::has('email_your_name')? '/'.Cfg::get('email_your_name', '') : ''}}
+                {{ config('app.name') }} {{Cfg::has('email_your_name')? '/'.Cfg::get('email_your_name', null, '') : ''}}
             </p>
         </td>
     </tr>

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,9 +1,11 @@
 <?php
 
 use App\Facades\Cfg;
+use App\Services\Schedule\ScheduleConfigFactory;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Schedule;
+use Illuminate\Support\Facades\Schema;
 
 $email = config('mail.log.email');
 
@@ -20,7 +22,7 @@ Schedule::command('weekly:run')
 
 // video-Import aus Upload-Ordner – alle 30 Minuten
 Schedule::command('ingest:scan', [
-    '--inbox' => Cfg::get('ingest_inbox_absolute_path', '/srv/ingest/pending/'),
+    '--inbox' => Cfg::get('ingest_inbox_absolute_path', null, '/srv/ingest/pending/'),
 ])->hourly()
     ->emailOutputOnFailure($email);
 
@@ -32,3 +34,8 @@ Schedule::command('assign:expire')
 // Dropbox Refresh Token regelmäßig aktualisieren
 Schedule::command('dropbox:refresh-token')
     ->everyMinute();
+
+// Dynamische Cronjobs aus Datenbank-Konfiguration
+if (Schema::hasTable('configs')) {
+    app(ScheduleConfigFactory::class)->register(app(\Illuminate\Console\Scheduling\Schedule::class));
+}

--- a/tests/Unit/Services/ConfigServiceTest.php
+++ b/tests/Unit/Services/ConfigServiceTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\Config;
+use App\Models\ConfigCategory;
+use App\Services\ConfigService;
+use Illuminate\Support\Facades\Cache;
+use Tests\DatabaseTestCase;
+
+class ConfigServiceTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::flush();
+    }
+
+    public function test_get_returns_default_category_value(): void
+    {
+        $category = ConfigCategory::where('key', 'default')->first();
+
+        Config::create([
+            'key' => 'admin_email',
+            'value' => 'admin@example.com',
+            'cast_type' => 'string',
+            'config_category_id' => $category->id,
+        ]);
+
+        $service = new ConfigService();
+
+        $this->assertSame('admin@example.com', $service->get('admin_email'));
+    }
+
+    public function test_get_uses_specified_category(): void
+    {
+        $schedule = ConfigCategory::where('key', 'schedule')->first();
+
+        Config::create([
+            'key' => 'schedule_test',
+            'value' => '1',
+            'cast_type' => 'string',
+            'config_category_id' => $schedule->id,
+        ]);
+
+        $service = new ConfigService();
+
+        $this->assertSame('1', $service->get('schedule_test', 'schedule'));
+        $this->assertNull($service->get('schedule_test'));
+    }
+
+    public function test_set_creates_updates_and_clears_cache(): void
+    {
+        $service = new ConfigService();
+
+        $service->set('foo:cmd', true, 'schedule', [
+            'frequency' => ['value' => '*/5 * * * *'],
+        ], 'bool');
+
+        $this->assertTrue($service->get('foo:cmd', 'schedule', false));
+        $this->assertSame('*/5 * * * *', $service->get('foo:cmd.frequency', 'schedule'));
+
+        $service->set('foo:cmd', false, 'schedule', [
+            'frequency' => ['value' => '0 * * * *'],
+        ], 'bool');
+
+        $this->assertFalse($service->get('foo:cmd', 'schedule', true));
+        $this->assertSame('0 * * * *', $service->get('foo:cmd.frequency', 'schedule'));
+    }
+}
+


### PR DESCRIPTION
## Summary
- cache configs and sub-settings under hierarchical keys
- build schedule events from `schedule` configs
- bootstrap console schedules from database when available
- allow fetching config values by explicit category, defaulting to `default`
- insert default configuration categories and an `ingest:scan` schedule config via migration
- expose a `ConfigService::set` method to upsert configs and sub-settings with cache invalidation
- reorder `ConfigService::get` parameters so category precedes the default and update call sites

## Testing
- `composer install --no-scripts`
- `CACHE_STORE=array CACHE_DRIVER=array DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan migrate --force`
- `CACHE_STORE=array CACHE_DRIVER=array DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_689da2bd977883299ab3277454099743