### PR TITLE
Skip schedule config during composer scripts

### DIFF
--- a/app/Providers/ScheduleConfigProvider.php
+++ b/app/Providers/ScheduleConfigProvider.php
@@ -27,7 +27,11 @@ class ScheduleConfigProvider extends ServiceProvider implements DeferrableProvid
 
     public function boot(): void
     {
-        if (!$this->app->runningInConsole() || $this->isComposerPostCmd() || !$this->hasRequiredTables()) {
+        if (
+            !$this->app->runningInConsole()
+            || !ScheduleConfigFactory::composerHasFinished()
+            || !$this->hasRequiredTables()
+        ) {
             return;
         }
         $this->app->afterResolving(Schedule::class, function (Schedule $schedule) {
@@ -42,34 +46,17 @@ class ScheduleConfigProvider extends ServiceProvider implements DeferrableProvid
 
     protected function hasRequiredTables(): bool
     {
-        $result = true;
-        foreach (self::REQUIRED_TABLES as $table) {
-            $tmpResult = Schema::hasTable($table);
-            if ($tmpResult === false) {
-                $result = false;
-                break;
+        try {
+            foreach (self::REQUIRED_TABLES as $table) {
+                if (!Schema::hasTable($table)) {
+                    return false;
+                }
             }
-        }
-        return $result;
-    }
-
-    private function isComposerPostCmd(): bool
-    {
-        if (!app()->runningInConsole()) {
+        } catch (\Throwable $e) {
             return false;
         }
-        $isComposer = getenv('COMPOSER_BINARY') !== false
-            || str_contains($_SERVER['argv'][0] ?? '', 'composer');
 
-        $laravelPostCmds = [
-            'package:discover',
-            'config:cache',
-            'event:cache',
-            'route:cache',
-            'view:cache',
-        ];
-        $isKnownArtisanPostCmd = in_array($_SERVER['argv'][1] ?? '', $laravelPostCmds, true);
-
-        return $isComposer && $isKnownArtisanPostCmd;
+        return true;
     }
+
 }

--- a/app/Services/Schedule/ScheduleConfigFactory.php
+++ b/app/Services/Schedule/ScheduleConfigFactory.php
@@ -16,6 +16,20 @@ class ScheduleConfigFactory implements ScheduleConfigFactoryInterface
     }
 
     /**
+     * Determine if Composer has finished running to avoid triggering console
+     * bootstrapping during install or update scripts.
+     */
+    public static function composerHasFinished(): bool
+    {
+        if (!app()->runningInConsole()) {
+            return true;
+        }
+
+        return getenv('COMPOSER_BINARY') === false
+            && !str_contains($_SERVER['argv'][0] ?? '', 'composer');
+    }
+
+    /**
      * Register schedule events for all configs within the "schedule" category.
      */
     public function register(Schedule $schedule): void

--- a/config/app.php
+++ b/config/app.php
@@ -125,4 +125,8 @@ return [
         'store' => env('APP_MAINTENANCE_STORE', 'database'),
     ],
 
+    'aliases' => Illuminate\Support\Facades\Facade::defaultAliases()
+        ->except(['Redis'])
+        ->toArray(),
+
 ];


### PR DESCRIPTION
## Summary
- Skip schedule configuration during Composer scripts using a factory helper
- Drop Redis facade alias to avoid collision with the PHP extension

## Testing
- `composer install`
- `composer test` *(fails: Script @php artisan config:clear --ansi handling the test event returned with error code 1)*

------
https://chatgpt.com/codex/tasks/task_e_689dbd20b97c83298917617cb8173a75