### PR TITLE
feat: add batch resource with tabs and channel links

### DIFF
--- a/app/Filament/Resources/BatchResource.php
+++ b/app/Filament/Resources/BatchResource.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\BatchResource\Pages;
+use App\Filament\Resources\BatchResource\RelationManagers\AssignmentsRelationManager;
+use App\Filament\Resources\BatchResource\RelationManagers\ClipsRelationManager;
+use App\Filament\Resources\BatchResource\RelationManagers\ChannelsRelationManager;
+use App\Models\Batch;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class BatchResource extends Resource
+{
+    protected static ?string $model = Batch::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-queue-list';
+    protected static ?string $navigationGroup = 'System';
+    protected static ?string $modelLabel = 'Batch';
+    protected static ?string $pluralModelLabel = 'Batches';
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([
+            Forms\Components\TextInput::make('id')->disabled(),
+            Forms\Components\TextInput::make('type')->disabled(),
+            Forms\Components\DateTimePicker::make('started_at')->disabled(),
+            Forms\Components\DateTimePicker::make('finished_at')->disabled(),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->defaultSort('id', 'desc')
+            ->columns([
+                TextColumn::make('id')->sortable(),
+                TextColumn::make('type')->badge()->sortable(),
+                TextColumn::make('started_at')->dateTime()->since()->sortable(),
+                TextColumn::make('finished_at')->dateTime()->since()->sortable()->toggleable(),
+                TextColumn::make('assignments_count')
+                    ->counts('assignments')
+                    ->label('Assignments'),
+            ])
+            ->filters([]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            AssignmentsRelationManager::class,
+            ClipsRelationManager::class,
+            ChannelsRelationManager::class,
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListBatches::route('/'),
+            'view' => Pages\ViewBatch::route('/{record}'),
+        ];
+    }
+}

--- a/app/Filament/Resources/BatchResource/Pages/ListBatches.php
+++ b/app/Filament/Resources/BatchResource/Pages/ListBatches.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Filament\Resources\BatchResource\Pages;
+
+use App\Filament\Resources\BatchResource;
+use Filament\Resources\Components\Tab;
+use Filament\Resources\Pages\ListRecords;
+
+class ListBatches extends ListRecords
+{
+    protected static string $resource = BatchResource::class;
+
+    public function getTabs(): array
+    {
+        return [
+            'ingest' => Tab::make()->query(fn($query) => $query->where('type', 'ingest')),
+            'assign' => Tab::make()->query(fn($query) => $query->where('type', 'assign')),
+            'notify' => Tab::make()->query(fn($query) => $query->where('type', 'notify')),
+        ];
+    }
+}

--- a/app/Filament/Resources/BatchResource/Pages/ViewBatch.php
+++ b/app/Filament/Resources/BatchResource/Pages/ViewBatch.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\BatchResource\Pages;
+
+use App\Filament\Resources\BatchResource;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewBatch extends ViewRecord
+{
+    protected static string $resource = BatchResource::class;
+}

--- a/app/Filament/Resources/BatchResource/RelationManagers/AssignmentsRelationManager.php
+++ b/app/Filament/Resources/BatchResource/RelationManagers/AssignmentsRelationManager.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Filament\Resources\BatchResource\RelationManagers;
+
+use App\Filament\Resources\AssignmentResource;
+use App\Models\Assignment;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class AssignmentsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'assignments';
+    protected static ?string $title = 'Assignments';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->recordTitleAttribute('id')
+            ->columns([
+                TextColumn::make('id')->sortable(),
+                TextColumn::make('channel.name')
+                    ->label('Channel')
+                    ->sortable()
+                    ->searchable(),
+                TextColumn::make('status')->badge()->sortable(),
+                TextColumn::make('attempts')->numeric()->sortable(),
+                TextColumn::make('expires_at')->dateTime()->since()->sortable(),
+                TextColumn::make('last_notified_at')->dateTime()->since()->sortable()->toggleable(),
+                TextColumn::make('video.preview_url')
+                    ->label('Preview')
+                    ->formatStateUsing(fn() => 'Open')
+                    ->url(fn(Assignment $assignment) => $assignment->video ? (string)$assignment->video->getAttribute('preview_url') : null)
+                    ->openUrlInNewTab(),
+                TextColumn::make('created_at')->dateTime()->since()->sortable(),
+            ])
+            ->headerActions([])
+            ->actions([
+                Tables\Actions\Action::make('open')
+                    ->label('Open')
+                    ->icon('heroicon-m-arrow-top-right-on-square')
+                    ->url(fn (Assignment $assignment) => AssignmentResource::getUrl('view', ['record' => $assignment]))
+                    ->openUrlInNewTab(),
+                Tables\Actions\Action::make('preview')
+                    ->label('Open preview')
+                    ->icon('heroicon-m-play')
+                    ->url(fn (Assignment $assignment) => $assignment->video ? (string)$assignment->video->getAttribute('preview_url') : null)
+                    ->visible(fn(Assignment $assignment) => $assignment->video && filled($assignment->video->getAttribute('preview_url')))
+                    ->openUrlInNewTab(),
+            ])
+            ->bulkActions([]);
+    }
+}

--- a/app/Filament/Resources/BatchResource/RelationManagers/ChannelsRelationManager.php
+++ b/app/Filament/Resources/BatchResource/RelationManagers/ChannelsRelationManager.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Filament\Resources\BatchResource\RelationManagers;
+
+use App\Models\Channel;
+use App\Services\LinkService;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class ChannelsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'channels';
+    protected static ?string $title = 'Channels';
+
+    public function table(Table $table): Table
+    {
+        $linkCallback = function (Channel $channel): string {
+            $batch = $this->getOwnerRecord();
+            $assignment = $channel->assignments()
+                ->where('batch_id', $batch->getKey())
+                ->orderBy('expires_at')
+                ->first();
+
+            $expireAt = $assignment?->expires_at ?? now();
+
+            return app(LinkService::class)->getOfferUrl($batch, $channel, $expireAt);
+        };
+
+        return $table
+            ->recordTitleAttribute('name')
+            ->columns([
+                Tables\Columns\TextColumn::make('id')->sortable(),
+                Tables\Columns\TextColumn::make('name')
+                    ->label('Channel')
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('offer_link')
+                    ->label('Link')
+                    ->getStateUsing($linkCallback)
+                    ->url($linkCallback)
+                    ->copyable()
+                    ->openUrlInNewTab(),
+            ])
+            ->headerActions([])
+            ->actions([])
+            ->bulkActions([]);
+    }
+}

--- a/app/Filament/Resources/BatchResource/RelationManagers/ClipsRelationManager.php
+++ b/app/Filament/Resources/BatchResource/RelationManagers/ClipsRelationManager.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Filament\Resources\BatchResource\RelationManagers;
+
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class ClipsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'clips';
+    protected static ?string $title = 'Clips';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->recordTitleAttribute('id')
+            ->columns([
+                Tables\Columns\TextColumn::make('id')->sortable(),
+                Tables\Columns\TextColumn::make('video.original_name')
+                    ->label('Video')
+                    ->searchable()
+                    ->limit(40),
+                Tables\Columns\TextColumn::make('start_sec')->label('Start'),
+                Tables\Columns\TextColumn::make('end_sec')->label('End'),
+                Tables\Columns\TextColumn::make('created_at')->dateTime()->since(),
+            ])
+            ->headerActions([])
+            ->actions([Tables\Actions\ViewAction::make()])
+            ->bulkActions([]);
+    }
+}

--- a/app/Models/Batch.php
+++ b/app/Models/Batch.php
@@ -6,6 +6,13 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+
+/**
+ * @property array<string,mixed>|null $stats
+ */
 
 class Batch extends Model
 {
@@ -13,4 +20,26 @@ class Batch extends Model
 
     protected $fillable = ['type', 'started_at', 'finished_at', 'stats'];
     protected $casts = ['started_at' => 'datetime', 'finished_at' => 'datetime', 'stats' => 'array'];
+
+    public function assignments(): HasMany
+    {
+        return $this->hasMany(Assignment::class);
+    }
+
+    public function clips(): HasManyThrough
+    {
+        return $this->hasManyThrough(
+            Clip::class,
+            Assignment::class,
+            'batch_id', // Foreign key on assignments table
+            'video_id', // Foreign key on clips table
+            'id',       // Local key on batches table
+            'video_id'  // Local key on assignments table
+        );
+    }
+
+    public function channels(): BelongsToMany
+    {
+        return $this->belongsToMany(Channel::class, 'assignments', 'batch_id', 'channel_id');
+    }
 }

--- a/tests/Integration/Filament/Resources/BatchResourceTest.php
+++ b/tests/Integration/Filament/Resources/BatchResourceTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Filament\Resources;
+
+use App\Filament\Resources\BatchResource\Pages\ListBatches;
+use App\Filament\Resources\BatchResource\Pages\ViewBatch;
+use App\Models\Assignment;
+use App\Models\Batch;
+use App\Models\Clip;
+use App\Models\Channel;
+use App\Models\User;
+use App\Models\Video;
+use App\Services\LinkService;
+use App\Filament\Resources\BatchResource\RelationManagers\ChannelsRelationManager;
+use Livewire\Livewire;
+use Tests\DatabaseTestCase;
+
+final class BatchResourceTest extends DatabaseTestCase
+{
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
+    }
+
+    public function testListBatchesShowsTabsAndAssignmentCount(): void
+    {
+        $ingest = Batch::factory()->type('ingest')->create();
+        $notify = Batch::factory()->type('notify')->create();
+        $assign = Batch::factory()->type('assign')->create();
+
+        Assignment::factory()->count(5)->withBatch($assign)->create();
+
+        Livewire::test(ListBatches::class, ['activeTab' => 'assign'])
+            ->loadTable()
+            ->assertCanSeeTableRecords([$assign])
+            ->assertCanNotSeeTableRecords([$ingest, $notify])
+            ->assertTableColumnExists('assignments_count');
+
+        Livewire::test(ListBatches::class, ['activeTab' => 'ingest'])
+            ->assertCanSeeTableRecords([$ingest])
+            ->assertCanNotSeeTableRecords([$assign, $notify]);
+
+        Livewire::test(ListBatches::class, ['activeTab' => 'notify'])
+            ->assertCanSeeTableRecords([$notify])
+            ->assertCanNotSeeTableRecords([$assign, $ingest]);
+    }
+
+    public function testViewBatchShowsRelations(): void
+    {
+        $batch = Batch::factory()->type('assign')->create();
+        $video = Video::factory()->create();
+        $channel = Channel::factory()->create();
+        Clip::factory()->forVideo($video)->create();
+        $assignment = Assignment::factory()
+            ->forVideo($video)
+            ->forChannel($channel)
+            ->withBatch($batch)
+            ->create();
+
+        $link = app(LinkService::class)->getOfferUrl($batch, $channel, $assignment->expires_at);
+
+        Livewire::test(ViewBatch::class, ['record' => $batch->getKey()])
+            ->assertStatus(200)
+            ->assertSeeText('Assignments')
+            ->assertSeeText('Clips')
+            ->assertSeeText('Channels');
+
+        Livewire::test(ChannelsRelationManager::class, [
+            'ownerRecord' => $batch,
+            'pageClass' => ViewBatch::class,
+        ])
+            ->assertCanSeeTableRecords([$channel])
+            ->assertSee($link);
+    }
+}


### PR DESCRIPTION
## Summary
- add relation for channels to batches, exposing offer link per channel
- include channels relation manager in Filament batch resource
- extend integration tests for channels relation and offer link

## Testing
- `composer install`
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68a3472919d4832981858587496e3bef