### PR TITLE
test: cover ingest unzip and scan locking

### DIFF
--- a/tests/Feature/Console/IngestUnzipTest.php
+++ b/tests/Feature/Console/IngestUnzipTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Console\Command;
+use Tests\DatabaseTestCase;
+use ZipArchive;
+
+final class IngestUnzipTest extends DatabaseTestCase
+{
+    public function testRunsExtractionAndRendersStats(): void
+    {
+        $dir = storage_path('app/unzip_'.bin2hex(random_bytes(4)));
+        mkdir($dir, 0777, true);
+
+        $zip = new ZipArchive();
+        $zip->open($dir.'/good.zip', ZipArchive::CREATE);
+        $zip->addFromString('ok.txt', 'hi');
+        $zip->close();
+
+        $this->artisan("ingest:unzip {$dir}")
+            ->expectsOutput('Done. total=1 extracted=1 failed=0 skipped=0')
+            ->expectsOutput('Extracted: good.zip')
+            ->assertExitCode(Command::SUCCESS);
+
+        $this->assertFileExists($dir.'/ok.txt');
+        $this->assertFileDoesNotExist($dir.'/good.zip');
+    }
+
+    public function testReturnsFailureWhenDirectoryMissing(): void
+    {
+        $dir = storage_path('app/missing_'.bin2hex(random_bytes(4)));
+
+        $this->artisan("ingest:unzip {$dir}")
+            ->expectsOutput("Directory not found or not readable: {$dir}")
+            ->assertExitCode(Command::FAILURE);
+    }
+
+    public function testAbortsWhenLockIsHeld(): void
+    {
+        $lock = cache()->lock('ingest:lock', 10);
+        $this->assertTrue($lock->get());
+
+        $dir = storage_path('app/unzip_'.bin2hex(random_bytes(4)));
+        mkdir($dir, 0777, true);
+
+        $this->artisan("ingest:unzip {$dir}")
+            ->expectsOutput('Another ingest task is running. Abort.')
+            ->assertExitCode(Command::SUCCESS);
+
+        $lock->release();
+    }
+}


### PR DESCRIPTION
## Summary
- ensure ingest:scan aborts when lock is held
- add feature tests for ingest:unzip command

## Testing
- `./vendor/bin/phpunit tests/Feature/Console/IngestScanTest.php tests/Feature/Console/IngestUnzipTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68a44bc09c0483298c8708fd717d6a45