### PR TITLE
Refactor LockJobTraitTest for reliable execution

### DIFF
--- a/tests/Unit/Console/Commands/Traits/LockJobTraitTest.php
+++ b/tests/Unit/Console/Commands/Traits/LockJobTraitTest.php
@@ -25,6 +25,10 @@ final class LockJobTraitTest extends TestCase
         $app = new Container();
         Facade::setFacadeApplication($app);
 
+        // Replace Cache facade with a mock so shouldReceive() works without
+        // needing a full cache manager binding.
+        Cache::swap(Mockery::mock());
+
         // (Optional) Provide a dummy config repository if something resolves it
         $app->instance('config', new class {
             public array $items = ['cache.default' => 'array'];

--- a/tests/Unit/Console/Commands/Traits/UsesLockJobTraitClass.php
+++ b/tests/Unit/Console/Commands/Traits/UsesLockJobTraitClass.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Console\Commands\Traits;
 
 use App\Console\Commands\Traits\LockJobTrait;
+use Closure;
 
 /**
  * A small helper class exposing LockJobTrait's protected methods for testing.


### PR DESCRIPTION
## Summary
- mock Cache facade in tests to avoid missing cache binding
- import global Closure in UsesLockJobTraitClass

## Testing
- `./vendor/bin/phpunit tests/Unit/Console/Commands/Traits/LockJobTraitTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68a458dda08c8329a5e857ade431c985