### PR TITLE
docs: expand 2.0.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Settings are now grouped into categories and cached for faster access.
 - New "Batches" page in the admin area shows videos, channels and offers together.
 - All expiration times for links now follow one consistent rule.
+- New `ingest:unzip` command extracts pending archives automatically.
+- Scheduler entry for `ingest:unzip` runs the extraction every ten minutes.
+- Shared locking via `LockJobTrait` prevents parallel runs of ingest commands.
 
 ### Changed
 
 - The way the app reads settings has changed. If you have custom tools that fetch settings, they may need updates.
 - Standardized batch handling by introducing `BatchTypeEnum` and migrating usages from the previously mixed enum.
+- `ingest:scan` now supports lock options and a configurable target disk.
+- Cron failures send notifications to the admin email setting instead of a fixed address.
 
 ### Removed
 


### PR DESCRIPTION
## Summary
- document new `ingest:unzip` command and its scheduler
- note shared locking for ingest commands
- mention lock options and admin email config changes

## Testing
- `composer install --no-interaction --no-progress`
- `composer test` *(fails: Script @php artisan test handling the test event returned with error code 1)*
- `phpunit` *(fails: exit code 1 - No code coverage driver with path coverage support available)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b2ea6e0883299b28a0747b531949