### PR TITLE
docs: add deployment guide for Deployer

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Ausführliche Erläuterungen zu Aufbau und Nutzung finden sich im Verzeichnis [`
 - [Setup](docs/setup.md)
 - [Werkzeuge](docs/tool.md)
 - [Workflow](docs/workflow.md)
+- [Deployment](docs/deployment.md)
 
 ## Tests
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,4 +7,5 @@ Dieses Verzeichnis enthält ergänzende Informationen zur Video-Sharing-Plattfor
 - [Setup](setup.md)
 - [Werkzeuge](tool.md)
 - [Workflow](workflow.md)
+- [Deployment](deployment.md)
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,22 @@
+# Deployment mit Deployer
+
+Diese Anleitung beschreibt den Einsatz von [Deployer](https://deployer.org) zum automatischen Ausrollen der Anwendung.
+
+## Vorbereitung
+
+1. Beispieldatei kopieren und anpassen:
+   ```bash
+   cp deploy.php.dist deploy.php
+   ```
+2. In `deploy.php` den GitHub Personal Access Token (`GITHUB_PAT`) und die Ziel-Hosts eintragen.
+
+## Deployment ausführen
+
+Die Datei `deployer.phar` liegt im Projektverzeichnis. Ein Deployment wird mit folgendem Befehl gestartet:
+
+```bash
+php deployer.phar deploy prd
+```
+
+Dabei bezeichnet `prd` den in `deploy.php` definierten Host. Weitere Details bietet die [Dokumentation von Deployer](https://deployer.org/docs).
+


### PR DESCRIPTION
## Summary
- document deploying the app with Deployer and renaming `deploy.php.dist`
- link the new deployment guide in documentation overviews

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68a598a0aa3483298ced001ab46c6c0f