### PR TITLE
docs(changelog): log viewer and deployment guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `ingest:unzip` command extracts pending archives automatically.
 - Scheduler entry for `ingest:unzip` runs the extraction every ten minutes.
 - Shared locking via `LockJobTrait` prevents parallel runs of ingest commands.
+- Admin panel includes a log viewer for inspecting application logs.
+- Deployment guide added to the documentation.
 
 ### Changed
 


### PR DESCRIPTION
## Summary
- document log viewer availability in admin panel
- add deployment guide to changelog

## Testing
- `composer test` *(fails: Script @php artisan test handling the test event returned with error code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a5e026d8832985339021a50c8700