### PR TITLE
docs: update changelog for dropbox connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Scheduler entry for `ingest:unzip` runs the extraction every ten minutes.
 - Shared locking via `LockJobTrait` prevents parallel runs of ingest commands.
 - Admin panel includes a log viewer for inspecting application logs.
+- Admin panel includes a Dropbox connect page for linking accounts.
 - Deployment guide added to the documentation.
 
 ### Changed
@@ -28,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Removed the old type enum and related aliases. **Breaking change:** public APIs now accept `BatchTypeEnum`.
+
+### Fixed
+
+- Empty Dropbox refresh tokens no longer count as connected.
 
 ## [1.2.1] - 2025-08-18
 


### PR DESCRIPTION
## Summary
- document Dropbox connection page
- note fix for handling empty Dropbox tokens

## Testing
- `composer test` *(fails: Script @php artisan test handling the test event returned with error code 1, though logs show 176 tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5af8b202883298ed0ee38c8e9cb12