### PR TITLE
Check Dropbox connection expiry before marking connected

### DIFF
--- a/app/Filament/Pages/DropboxConnect.php
+++ b/app/Filament/Pages/DropboxConnect.php
@@ -3,7 +3,9 @@
 namespace App\Filament\Pages;
 
 use App\Models\Config;
+use Carbon\Carbon;
 use Filament\Pages\Page;
+use Illuminate\Support\Facades\Cache;
 
 class DropboxConnect extends Page
 {
@@ -19,12 +21,17 @@ class DropboxConnect extends Page
 
     public bool $connected = false;
 
+    public ?Carbon $expiresAt = null;
+
     public function mount(): void
     {
         $token = Config::query()
             ->where('key', 'dropbox_refresh_token')
             ->value('value');
 
-        $this->connected = filled($token);
+        $expire = Cache::get('dropbox.expire_at');
+        $this->expiresAt = $expire instanceof Carbon ? $expire : null;
+
+        $this->connected = filled($token) && $this->expiresAt?->isFuture();
     }
 }

--- a/resources/views/filament/pages/dropbox-connect.blade.php
+++ b/resources/views/filament/pages/dropbox-connect.blade.php
@@ -2,6 +2,9 @@
     <div class="space-y-6">
         @if ($connected)
             <p class="text-success-600">Dein Dropbox-Konto ist verbunden.</p>
+            @if ($expiresAt)
+                <p class="text-sm text-gray-500">Key läuft ab am {{ $expiresAt->format('d.m.Y H:i') }} Uhr.</p>
+            @endif
         @else
             <p>Verbinde dein Konto mit Dropbox, um Dateien importieren zu können.</p>
         @endif

--- a/tests/Feature/Filament/Pages/DropboxConnectTest.php
+++ b/tests/Feature/Filament/Pages/DropboxConnectTest.php
@@ -6,6 +6,8 @@ namespace Tests\Feature\Filament\Pages;
 
 use App\Filament\Pages\DropboxConnect;
 use App\Models\Config;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Cache;
 use Tests\DatabaseTestCase;
 
 final class DropboxConnectTest extends DatabaseTestCase
@@ -13,6 +15,7 @@ final class DropboxConnectTest extends DatabaseTestCase
     public function test_connected_is_false_when_token_missing(): void
     {
         Config::query()->where('key', 'dropbox_refresh_token')->delete();
+        Cache::forget('dropbox.expire_at');
 
         $page = app(DropboxConnect::class);
         $page->mount();
@@ -23,6 +26,7 @@ final class DropboxConnectTest extends DatabaseTestCase
     public function test_connected_is_false_when_token_empty(): void
     {
         Config::query()->where('key', 'dropbox_refresh_token')->update(['value' => '']);
+        Cache::forget('dropbox.expire_at');
 
         $page = app(DropboxConnect::class);
         $page->mount();
@@ -30,13 +34,26 @@ final class DropboxConnectTest extends DatabaseTestCase
         $this->assertFalse($page->connected);
     }
 
-    public function test_connected_is_true_when_token_present(): void
+    public function test_connected_is_false_when_expired(): void
     {
         Config::query()->where('key', 'dropbox_refresh_token')->update(['value' => 'TOKEN123']);
+        Cache::forever('dropbox.expire_at', Carbon::now()->subMinute());
+
+        $page = app(DropboxConnect::class);
+        $page->mount();
+
+        $this->assertFalse($page->connected);
+    }
+
+    public function test_connected_is_true_when_token_present_and_not_expired(): void
+    {
+        Config::query()->where('key', 'dropbox_refresh_token')->update(['value' => 'TOKEN123']);
+        Cache::forever('dropbox.expire_at', Carbon::now()->addMinutes(5));
 
         $page = app(DropboxConnect::class);
         $page->mount();
 
         $this->assertTrue($page->connected);
+        $this->assertInstanceOf(Carbon::class, $page->expiresAt);
     }
 }


### PR DESCRIPTION
## Summary
- Validate Dropbox connection against cached expiration time
- Show token expiration date in Dropbox settings page
- Cover connection expiry scenarios with tests

## Testing
- `./vendor/bin/phpunit` *(fails: No code coverage driver with path coverage support available)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b239e5a88329a5575f8903e6183b