### PR TITLE
feat: add downloads resource to filament

### DIFF
--- a/app/Filament/Resources/DownloadResource.php
+++ b/app/Filament/Resources/DownloadResource.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\DownloadResource\Pages;
+use App\Models\Download;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class DownloadResource extends Resource
+{
+    protected static ?string $model = Download::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-arrow-down-tray';
+    protected static ?string $navigationGroup = 'Media';
+    protected static ?string $modelLabel = 'Download';
+    protected static ?string $pluralModelLabel = 'Downloads';
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->defaultSort('updated_at', 'desc')
+            ->columns([
+                TextColumn::make('assignment.id')
+                    ->label('Assignment ID')
+                    ->sortable(),
+                TextColumn::make('assignment.status')
+                    ->label('Status')
+                    ->sortable()
+                    ->searchable(),
+                TextColumn::make('ip')
+                    ->sortable()
+                    ->searchable(),
+                TextColumn::make('assignment.channel.name')
+                    ->label('Channel')
+                    ->sortable()
+                    ->searchable(),
+                TextColumn::make('assignment.video_id')
+                    ->label('Video ID')
+                    ->sortable(),
+                TextColumn::make('updated_at')
+                    ->label('Updated')
+                    ->dateTime()
+                    ->since()
+                    ->sortable(),
+            ])
+            ->filters([])
+            ->actions([])
+            ->bulkActions([]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListDownloads::route('/'),
+        ];
+    }
+}

--- a/app/Filament/Resources/DownloadResource/Pages/ListDownloads.php
+++ b/app/Filament/Resources/DownloadResource/Pages/ListDownloads.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\DownloadResource\Pages;
+
+use App\Filament\Resources\DownloadResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListDownloads extends ListRecords
+{
+    protected static string $resource = DownloadResource::class;
+}

--- a/tests/Integration/Filament/Resources/DownloadResourceTest.php
+++ b/tests/Integration/Filament/Resources/DownloadResourceTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Filament\Resources;
+
+use App\Filament\Resources\DownloadResource\Pages\ListDownloads;
+use App\Models\Assignment;
+use App\Models\Batch;
+use App\Models\Channel;
+use App\Models\Download;
+use App\Models\User;
+use App\Models\Video;
+use Livewire\Livewire;
+use Tests\DatabaseTestCase;
+
+final class DownloadResourceTest extends DatabaseTestCase
+{
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
+    }
+
+    public function testListShowsDownloadData(): void
+    {
+        $channel = Channel::factory()->create(['name' => 'Main Channel']);
+        $video = Video::factory()->create();
+        $batch = Batch::factory()->type('assign')->create();
+        $assignment = Assignment::factory()
+            ->forChannel($channel)
+            ->forVideo($video)
+            ->withBatch($batch)
+            ->create(['status' => 'queued']);
+
+        $download = Download::factory()
+            ->forAssignment($assignment)
+            ->create(['ip' => '203.0.113.1']);
+
+        Livewire::test(ListDownloads::class)
+            ->assertStatus(200)
+            ->assertSee((string) $assignment->id)
+            ->assertSee($assignment->status)
+            ->assertSee('203.0.113.1')
+            ->assertSee($channel->name)
+            ->assertSee((string) $assignment->video_id);
+    }
+}


### PR DESCRIPTION
## Summary
- add Filament Downloads resource with assignment, channel and video info
- cover downloads list with integration test

## Testing
- `composer test` *(fails: Tests\Feature\Http\Controllers\DropboxControllerTest > callback exchanges code persists refresh token and clears cached access token)*


------
https://chatgpt.com/codex/tasks/task_e_68a84f4420088329a25b20ba636f6208