### PR TITLE
refactor: split cleanup repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2025-08-21
+
+### Added
+
+- Daily `video:cleanup` cron job removes videos once their picked-up assignments have been downloaded and expired for over a week.
+
 ## [2.0.2] - 2025-08-20
 
 ### Fixed

--- a/app/Console/Commands/VideoCleanup.php
+++ b/app/Console/Commands/VideoCleanup.php
@@ -11,9 +11,9 @@ use Illuminate\Console\Command;
 
 class VideoCleanup extends Command
 {
-    protected $signature = 'video:cleanup';
+    protected $signature = 'video:cleanup {--weeks=1 : Anzahl der Wochen, die der Ablauf überschritten haben muss}';
 
-    protected $description = 'Löscht heruntergeladene Videos, deren Ablauf seit einer Woche überschritten ist.';
+    protected $description = 'Löscht heruntergeladene Videos, deren Ablauf seit der angegebenen Wochenzahl überschritten ist.';
 
     public function __construct(private VideoCleanupService $service)
     {
@@ -22,7 +22,8 @@ class VideoCleanup extends Command
 
     public function handle(): int
     {
-        $deleted = $this->service->cleanup();
+        $weeks = (int) $this->option('weeks');
+        $deleted = $this->service->cleanup($weeks);
         $this->info("Removed: {$deleted}");
 
         return self::SUCCESS;

--- a/app/Console/Commands/VideoCleanup.php
+++ b/app/Console/Commands/VideoCleanup.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+// app/Console/Commands/VideoCleanup.php
+
+namespace App\Console\Commands;
+
+use App\Services\VideoCleanupService;
+use Illuminate\Console\Command;
+
+class VideoCleanup extends Command
+{
+    protected $signature = 'video:cleanup';
+
+    protected $description = 'Löscht heruntergeladene Videos, deren Ablauf seit einer Woche überschritten ist.';
+
+    public function __construct(private VideoCleanupService $service)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $deleted = $this->service->cleanup();
+        $this->info("Removed: {$deleted}");
+
+        return self::SUCCESS;
+    }
+}
+

--- a/app/Repository/DownloadRepository.php
+++ b/app/Repository/DownloadRepository.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Enum\StatusEnum;
+use App\Models\Download;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+
+class DownloadRepository
+{
+    public function latestPerVideo(): Builder
+    {
+        return Download::query()
+            ->selectRaw('MAX(downloads.id) AS id')
+            ->join('assignments', 'downloads.assignment_id', '=', 'assignments.id')
+            ->groupBy('assignments.video_id');
+    }
+
+    public function fetchDownloadedVideoIds(Carbon $threshold): Collection
+    {
+        return Download::query()
+            ->join('assignments', 'downloads.assignment_id', '=', 'assignments.id')
+            ->joinSub($this->latestPerVideo(), 'latest', function ($join) {
+                $join->on('downloads.id', '=', 'latest.id');
+            })
+            ->where('assignments.status', StatusEnum::PICKEDUP->value)
+            ->where('assignments.expires_at', '<', $threshold)
+            ->pluck('assignments.video_id');
+    }
+}

--- a/app/Repository/VideoRepository.php
+++ b/app/Repository/VideoRepository.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Enum\StatusEnum;
+use App\Models\Video;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+
+class VideoRepository
+{
+    public function filterDeletableVideoIds(Collection $candidateIds, Carbon $threshold): Collection
+    {
+        if ($candidateIds->isEmpty()) {
+            return collect();
+        }
+
+        return Video::query()
+            ->whereIn('id', $candidateIds)
+            ->whereDoesntHave('assignments', function ($q) use ($threshold) {
+                $q->where('status', '!=', StatusEnum::PICKEDUP->value)
+                    ->orWhere('expires_at', '>=', $threshold)
+                    ->orWhereDoesntHave('downloads');
+            })
+            ->pluck('id');
+    }
+
+    public function deleteVideosByIds(Collection $videoIds): int
+    {
+        if ($videoIds->isEmpty()) {
+            return 0;
+        }
+
+        return Video::query()
+            ->whereIn('id', $videoIds)
+            ->delete();
+    }
+
+    public function fetchOriginalNames(Collection $videoIds): Collection
+    {
+        if ($videoIds->isEmpty()) {
+            return collect();
+        }
+
+        return Video::query()
+            ->whereIn('id', $videoIds)
+            ->pluck('original_name')
+            ->filter();
+    }
+}

--- a/app/Services/VideoCleanupService.php
+++ b/app/Services/VideoCleanupService.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Enum\BatchTypeEnum;
+use App\Models\Batch;
+use App\Repository\DownloadRepository;
+use App\Repository\VideoRepository;
+use Illuminate\Support\Carbon;
+
+class VideoCleanupService
+{
+    public function __construct(
+        private DownloadRepository $downloads,
+        private VideoRepository $videos,
+    ) {
+    }
+
+    public function cleanup(): int
+    {
+        $batch = Batch::query()->create([
+            'type' => BatchTypeEnum::REMOVE->value,
+            'started_at' => now(),
+        ]);
+
+        $threshold = Carbon::now()->subWeek();
+        $candidates = $this->downloads->fetchDownloadedVideoIds($threshold);
+        $deletable = $this->videos->filterDeletableVideoIds($candidates, $threshold);
+        $names = $this->videos->fetchOriginalNames($deletable);
+        $deleted = $this->videos->deleteVideosByIds($deletable);
+
+        $batch->update([
+            'finished_at' => now(),
+            'stats' => [
+                'removed' => $deleted,
+                'original_names' => $names->values()->all(),
+            ],
+        ]);
+
+        return $deleted;
+    }
+}
+

--- a/app/Services/VideoCleanupService.php
+++ b/app/Services/VideoCleanupService.php
@@ -18,14 +18,14 @@ class VideoCleanupService
     ) {
     }
 
-    public function cleanup(): int
+    public function cleanup(int $subWeeks = 1): int
     {
         $batch = Batch::query()->create([
             'type' => BatchTypeEnum::REMOVE->value,
             'started_at' => now(),
         ]);
 
-        $threshold = Carbon::now()->subWeek();
+        $threshold = Carbon::now()->subWeeks($subWeeks);
         $candidates = $this->downloads->fetchDownloadedVideoIds($threshold);
         $deletable = $this->videos->filterDeletableVideoIds($candidates, $threshold);
         $names = $this->videos->fetchOriginalNames($deletable);

--- a/routes/console.php
+++ b/routes/console.php
@@ -11,12 +11,10 @@ Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
 
-
 Schedule::command('weekly:run')
     ->mondays()
     ->at('08:00')
     ->emailOutputTo($email);
-
 
 Schedule::command('ingest:scan', [
     '--inbox' => Cfg::get('ingest_inbox_absolute_path', 'default', '/srv/ingest/pending/', true),
@@ -28,10 +26,12 @@ Schedule::command('ingest:unzip', [
 ])->everyTenMinutes()
     ->emailOutputOnFailure($email);
 
-
 Schedule::command('assign:expire')
     ->dailyAt('03:00');
 
+Schedule::command('video:cleanup')
+    ->dailyAt('04:00')
+    ->emailOutputOnFailure($email);
 
 // Dropbox Refresh Token regelmäßig aktualisieren
 Schedule::command('dropbox:refresh-token')

--- a/tests/Feature/Console/VideoCleanupTest.php
+++ b/tests/Feature/Console/VideoCleanupTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\Assignment;
+use App\Models\Batch;
+use App\Models\Channel;
+use App\Models\Download;
+use App\Models\Video;
+use App\Enum\BatchTypeEnum;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Tests\DatabaseTestCase;
+
+/**
+ * Feature tests for the "video:cleanup" console command.
+ */
+final class VideoCleanupTest extends DatabaseTestCase
+{
+    public function test_deletes_only_expired_picked_up_videos_with_download(): void
+    {
+        Carbon::setTestNow('2025-08-12 12:00:00');
+
+        $batch = Batch::factory()->state(['type' => 'assign'])
+            ->create(['started_at' => now()->subHour(), 'finished_at' => now()->subMinute()]);
+
+        // Video to delete (picked up, downloaded, expired >1 week)
+        $videoDel = Video::factory()->create();
+        $assignDel = Assignment::factory()
+            ->for($batch, 'batch')
+            ->for(Channel::factory()->create(), 'channel')
+            ->for($videoDel, 'video')
+            ->create([
+                'status' => 'picked_up',
+                'expires_at' => now()->subWeek()->subDay(),
+            ]);
+        Download::factory()->forAssignment($assignDel)->create();
+
+        // Not expired long enough
+        $videoFresh = Video::factory()->create();
+        $assignFresh = Assignment::factory()
+            ->for($batch, 'batch')
+            ->for(Channel::factory()->create(), 'channel')
+            ->for($videoFresh, 'video')
+            ->create([
+                'status' => 'picked_up',
+                'expires_at' => now()->subDays(3),
+            ]);
+        Download::factory()->forAssignment($assignFresh)->create();
+
+        // Missing download
+        $videoNoDl = Video::factory()->create();
+        Assignment::factory()
+            ->for($batch, 'batch')
+            ->for(Channel::factory()->create(), 'channel')
+            ->for($videoNoDl, 'video')
+            ->create([
+                'status' => 'picked_up',
+                'expires_at' => now()->subWeeks(2),
+            ]);
+
+        // Wrong status
+        $videoWrongStatus = Video::factory()->create();
+        $assignWrongStatus = Assignment::factory()
+            ->for($batch, 'batch')
+            ->for(Channel::factory()->create(), 'channel')
+            ->for($videoWrongStatus, 'video')
+            ->create([
+                'status' => 'queued',
+                'expires_at' => now()->subWeeks(2),
+            ]);
+        Download::factory()->forAssignment($assignWrongStatus)->create();
+
+        $this->artisan('video:cleanup')
+            ->expectsOutput('Removed: 1')
+            ->assertExitCode(Command::SUCCESS);
+
+        $this->assertDatabaseMissing('videos', ['id' => $videoDel->getKey()]);
+        $this->assertDatabaseHas('videos', ['id' => $videoFresh->getKey()]);
+        $this->assertDatabaseHas('videos', ['id' => $videoNoDl->getKey()]);
+        $this->assertDatabaseHas('videos', ['id' => $videoWrongStatus->getKey()]);
+
+        $batchRemove = Batch::query()->where('type', BatchTypeEnum::REMOVE->value)->latest('id')->first();
+        $this->assertNotNull($batchRemove);
+        $this->assertSame(1, $batchRemove->stats['removed']);
+        $this->assertEquals([$videoDel->original_name], $batchRemove->stats['original_names']);
+    }
+
+    public function test_skips_video_if_latest_download_assignment_not_picked_up(): void
+    {
+        Carbon::setTestNow('2025-08-12 12:00:00');
+
+        $batch = Batch::factory()->state(['type' => 'assign'])
+            ->create(['started_at' => now()->subHour(), 'finished_at' => now()->subMinute()]);
+
+        $video = Video::factory()->create();
+
+        $assignOld = Assignment::factory()
+            ->for($batch, 'batch')
+            ->for(Channel::factory()->create(), 'channel')
+            ->for($video, 'video')
+            ->create([
+                'status' => 'picked_up',
+                'expires_at' => now()->subWeeks(2),
+            ]);
+        Download::factory()->forAssignment($assignOld)->at(now()->subWeeks(2))->create();
+
+        $assignNew = Assignment::factory()
+            ->for($batch, 'batch')
+            ->for(Channel::factory()->create(), 'channel')
+            ->for($video, 'video')
+            ->create([
+                'status' => 'rejected',
+                'expires_at' => now()->subWeek()->subDay(),
+            ]);
+        Download::factory()->forAssignment($assignNew)->at(now()->subWeek())->create();
+
+        $this->artisan('video:cleanup')
+            ->expectsOutput('Removed: 0')
+            ->assertExitCode(Command::SUCCESS);
+
+        $this->assertDatabaseHas('videos', ['id' => $video->getKey()]);
+
+        $batchRemove = Batch::query()->where('type', BatchTypeEnum::REMOVE->value)->latest('id')->first();
+        $this->assertNotNull($batchRemove);
+        $this->assertSame(0, $batchRemove->stats['removed']);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce DownloadRepository to gather latest downloads and candidate video IDs
- move video filtering, deletion, and name lookups into VideoRepository
- update VideoCleanupService to orchestrate cleanup via the new repositories

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68a85dd4b39c8329b779aa20a9471e67