### PR TITLE
feat: add notification resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New batch type `remove` tracks cleanup runs.
 - Channels now receive reminder emails one day before assignment links expire, listing remaining video offers and recording the send in a notification history.
 - New setting `email_reminder_days` configures how many days in advance reminder emails are sent.
+- Admin panel now lists sent notifications with their channel, type, and send time.
 
 ### Changed
 

--- a/app/Filament/Resources/NotificationResource.php
+++ b/app/Filament/Resources/NotificationResource.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\NotificationResource\Pages;
+use App\Models\Notification;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class NotificationResource extends Resource
+{
+    protected static ?string $model = Notification::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-bell';
+
+    protected static ?string $navigationGroup = 'System';
+
+    protected static ?string $modelLabel = 'Notification';
+
+    protected static ?string $pluralModelLabel = 'Notifications';
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->defaultSort('id', 'desc')
+            ->columns([
+                TextColumn::make('id')->sortable(),
+                TextColumn::make('type')->badge()->sortable(),
+                TextColumn::make('channel.name')
+                    ->label('Channel')
+                    ->sortable()
+                    ->searchable(),
+                TextColumn::make('created_at')
+                    ->label('Sent at')
+                    ->dateTime()
+                    ->since()
+                    ->sortable(),
+            ])
+            ->filters([])
+            ->actions([])
+            ->bulkActions([]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListNotifications::route('/'),
+        ];
+    }
+}

--- a/app/Filament/Resources/NotificationResource/Pages/ListNotifications.php
+++ b/app/Filament/Resources/NotificationResource/Pages/ListNotifications.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\NotificationResource\Pages;
+
+use App\Filament\Resources\NotificationResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListNotifications extends ListRecords
+{
+    protected static string $resource = NotificationResource::class;
+}

--- a/tests/Integration/Filament/Resources/NotificationResourceTest.php
+++ b/tests/Integration/Filament/Resources/NotificationResourceTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Filament\Resources;
+
+use App\Filament\Resources\NotificationResource;
+use App\Filament\Resources\NotificationResource\Pages\ListNotifications;
+use App\Models\Notification;
+use App\Models\User;
+use Filament\Tables\Table;
+use Livewire\Livewire;
+use Tests\DatabaseTestCase;
+
+final class NotificationResourceTest extends DatabaseTestCase
+{
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
+    }
+
+    public function testNavigationGroupIsSystem(): void
+    {
+        $this->assertSame('System', NotificationResource::getNavigationGroup());
+    }
+
+    public function testTableDefaultSortIsIdDesc(): void
+    {
+        $page = app(ListNotifications::class);
+        $table = NotificationResource::table(Table::make($page));
+
+        $this->assertSame('id', $table->getDefaultSortColumn());
+        $this->assertSame('desc', $table->getDefaultSortDirection());
+    }
+
+    public function testListShowsNotificationsWithChannelAndType(): void
+    {
+        $first = Notification::factory()->create();
+        $second = Notification::factory()->create();
+
+        Livewire::test(ListNotifications::class)
+            ->assertStatus(200)
+            ->assertCanSeeTableRecords([$second, $first])
+            ->assertSee($first->channel->name)
+            ->assertSee($first->type)
+            ->assertSee($second->channel->name)
+            ->assertSee($second->type);
+    }
+}


### PR DESCRIPTION
## Summary
- add Filament resource to view notifications with channel, type, and sent time
- show notifications under the System navigation group

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68a8cadb08308329819e2f31b656569b