### PR TITLE
feat: add multi-video upload with clip bundling

### DIFF
--- a/app/Console/Commands/IngestScan.php
+++ b/app/Console/Commands/IngestScan.php
@@ -7,6 +7,7 @@ namespace App\Console\Commands;
 
 use App\Console\Commands\Traits\LockJobTrait;
 use App\Services\IngestScanner;
+use App\Facades\Cfg;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Cache\Lock;
 use RuntimeException;
@@ -17,7 +18,7 @@ class IngestScan extends Command
 
     protected $signature = 'ingest:scan
         {--inbox=/srv/ingest/pending : Root directory of uploads (recursive)}
-        {--disk=dropbox : Target storage disk (e.g., dropbox|local)}
+        {--disk= : Target storage disk (e.g., dropbox|local)}
         {--wait=0 : Seconds to wait for the lock (0 = non-blocking)}
         {--ttl=900 : Lock TTL in seconds}
         {--lock-store= : Optional cache store (e.g., redis)}';
@@ -41,7 +42,7 @@ class IngestScan extends Command
         }
 
         $inbox = rtrim((string)$this->option('inbox'), '/');
-        $disk = (string)$this->option('disk');
+        $disk = (string)($this->option('disk') ?: Cfg::get('default_file_system', 'default', 'dropbox'));
         $ttl = (int)$this->option('ttl');
         $waitSec = (int)$this->option('wait');
 

--- a/app/Filament/Pages/VideoUpload.php
+++ b/app/Filament/Pages/VideoUpload.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Jobs\ProcessUploadedVideo;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Pages\Page;
+use Filament\Notifications\Notification;
+use Illuminate\Support\Facades\Auth;
+
+class VideoUpload extends Page implements Forms\Contracts\HasForms
+{
+    use Forms\Concerns\InteractsWithForms;
+
+    protected static ?string $navigationIcon = 'heroicon-o-arrow-up-tray';
+    protected static ?string $navigationLabel = 'Video Upload';
+    protected static ?string $navigationGroup = 'Media';
+    protected static ?string $title = 'Video Upload';
+    protected static string $view = 'filament.pages.video-upload';
+
+    public ?array $data = [];
+
+    public function mount(): void
+    {
+        $this->form->fill();
+    }
+
+    public function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\Repeater::make('clips')
+                    ->label('Videos')
+                    ->defaultItems(1)
+                    ->schema([
+                        Forms\Components\FileUpload::make('file')
+                            ->label('Video')
+                            ->required()
+                            ->acceptedFileTypes(['video/*'])
+                            ->storeFiles(false),
+                        Forms\Components\View::make('clip')
+                            ->view('filament.forms.components.clip-selector')
+                            ->label('Ausschnitt')
+                            ->dehydrated(false),
+                        Forms\Components\TextInput::make('note')->label('Notiz'),
+                        Forms\Components\TextInput::make('bundle_key')->label('Bundle ID'),
+                        Forms\Components\TextInput::make('role')->label('Rolle'),
+                        Forms\Components\Hidden::make('start_sec')->default(0),
+                        Forms\Components\Hidden::make('end_sec')->default(0),
+                    ])
+            ])
+            ->statePath('data');
+    }
+
+    public function submit(): void
+    {
+        $state = $this->form->getState();
+        $user = Auth::user()?->name;
+
+        foreach ($state['clips'] ?? [] as $clip) {
+            /** @var \Livewire\Features\SupportFileUploads\TemporaryUploadedFile $file */
+            $file = $clip['file'];
+            $stored = $file->store('uploads/tmp');
+
+            ProcessUploadedVideo::dispatch(
+                path: storage_path('app/' . $stored),
+                originalName: $file->getClientOriginalName(),
+                ext: $file->getClientOriginalExtension(),
+                start: (int)($clip['start_sec'] ?? 0),
+                end: (int)($clip['end_sec'] ?? 0),
+                submittedBy: $user,
+                note: $clip['note'] ?? null,
+                bundleKey: $clip['bundle_key'] ?? null,
+                role: $clip['role'] ?? null,
+            );
+        }
+
+        Notification::make()
+            ->title('Videos werden verarbeitet')
+            ->success()
+            ->send();
+
+        $this->form->fill();
+    }
+}

--- a/app/Jobs/ProcessUploadedVideo.php
+++ b/app/Jobs/ProcessUploadedVideo.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Facades\Cfg;
+use App\Models\Video;
+use App\Services\IngestScanner;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class ProcessUploadedVideo implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    protected string $hash;
+
+    public function __construct(
+        public string $path,
+        public string $originalName,
+        public string $ext,
+        public int $start,
+        public int $end,
+        public ?string $submittedBy,
+        public ?string $note = null,
+        public ?string $bundleKey = null,
+        public ?string $role = null,
+    ) {
+        $this->hash = hash_file('sha256', $path);
+    }
+
+    public function handle(IngestScanner $scanner): void
+    {
+        $disk = Cfg::get('default_file_system', 'default', 'dropbox');
+        $scanner->processFile($this->path, $this->ext, $this->originalName, $disk);
+
+        $video = Video::query()->where('hash', $this->hash)->first();
+
+        if ($video) {
+            $video->clips()->create([
+                'start_sec' => $this->start,
+                'end_sec' => $this->end,
+                'submitted_by' => $this->submittedBy,
+                'note' => $this->note,
+                'bundle_key' => $this->bundleKey,
+                'role' => $this->role,
+            ]);
+        }
+    }
+}

--- a/database/migrations/2025_08_28_000000_add_default_file_system_config.php
+++ b/database/migrations/2025_08_28_000000_add_default_file_system_config.php
@@ -1,0 +1,28 @@
+<?php
+
+use Carbon\Carbon;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        $timestamp = Carbon::now()->format('Y-m-d H:i:s');
+        $defaultId = DB::table('config_categories')->where('slug', 'default')->value('id');
+
+        DB::table('configs')->insert([
+            'key' => 'default_file_system',
+            'value' => 'dropbox',
+            'cast_type' => 'string',
+            'is_visible' => 1,
+            'config_category_id' => $defaultId,
+            'created_at' => $timestamp,
+            'updated_at' => $timestamp,
+        ]);
+    }
+
+    public function down(): void
+    {
+        DB::table('configs')->where('key', 'default_file_system')->delete();
+    }
+};

--- a/resources/views/filament/forms/components/clip-selector.blade.php
+++ b/resources/views/filament/forms/components/clip-selector.blade.php
@@ -1,0 +1,37 @@
+<div
+    x-data="{
+        start: 0,
+        end: 0,
+        duration: 0,
+        init() {
+            const input = this.$el.parentElement.querySelector('input[type=file][wire\\:model$=\"file\"]');
+            input?.addEventListener('change', e => {
+                const file = e.target.files[0];
+                if (file) {
+                    this.$refs.video.src = URL.createObjectURL(file);
+                }
+            });
+            this.$refs.video.addEventListener('loadedmetadata', () => {
+                this.duration = this.$refs.video.duration;
+                if (this.end === 0 || this.end > this.duration) {
+                    this.end = this.duration;
+                }
+            });
+        }
+    }"
+    class="space-y-2"
+>
+    <video x-ref="video" controls class="w-full"></video>
+    <input type="hidden" x-model="start" wire:model="start_sec">
+    <input type="hidden" x-model="end" wire:model="end_sec">
+
+    <div class="flex items-center space-x-2">
+        <input type="range" x-model="start" min="0" :max="duration" step="1" class="w-full">
+        <input type="range" x-model="end" min="0" :max="duration" step="1" class="w-full">
+    </div>
+
+    <div class="text-sm">
+        Start: <span x-text="start"></span>s –
+        Ende: <span x-text="end"></span>s
+    </div>
+</div>

--- a/resources/views/filament/pages/video-upload.blade.php
+++ b/resources/views/filament/pages/video-upload.blade.php
@@ -1,0 +1,8 @@
+<x-filament::page>
+    <form wire:submit.prevent="submit" class="space-y-6">
+        {{ $this->form }}
+        <x-filament::button type="submit">
+            Upload
+        </x-filament::button>
+    </form>
+</x-filament::page>

--- a/tests/Feature/Filament/Pages/VideoUploadTest.php
+++ b/tests/Feature/Filament/Pages/VideoUploadTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament\Pages;
+
+use App\Filament\Pages\VideoUpload;
+use App\Jobs\ProcessUploadedVideo;
+use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Bus;
+use Tests\DatabaseTestCase;
+
+final class VideoUploadTest extends DatabaseTestCase
+{
+    public function testSubmitDispatchesJobForEachClip(): void
+    {
+        Bus::fake();
+
+        $user = User::factory()->create(['name' => 'Tester']);
+        $this->actingAs($user);
+
+        $path1 = storage_path('app/uploads/tmp/file1.mp4');
+        $path2 = storage_path('app/uploads/tmp/file2.mov');
+        @mkdir(dirname($path1), 0777, true);
+        file_put_contents($path1, 'a');
+        file_put_contents($path2, 'b');
+
+        $file1 = new class($path1)
+        {
+            public function __construct(private string $path) {}
+
+            public function store($dir): string
+            {
+                return 'uploads/tmp/'.basename($this->path);
+            }
+
+            public function getClientOriginalName(): string
+            {
+                return 'one.mp4';
+            }
+
+            public function getClientOriginalExtension(): string
+            {
+                return 'mp4';
+            }
+        };
+
+        $file2 = new class($path2)
+        {
+            public function __construct(private string $path) {}
+
+            public function store($dir): string
+            {
+                return 'uploads/tmp/'.basename($this->path);
+            }
+
+            public function getClientOriginalName(): string
+            {
+                return 'two.mov';
+            }
+
+            public function getClientOriginalExtension(): string
+            {
+                return 'mov';
+            }
+        };
+
+        $state = [
+            'clips' => [
+                [
+                    'file' => $file1,
+                    'start_sec' => 1,
+                    'end_sec' => 3,
+                    'note' => 'first',
+                    'bundle_key' => 'B1',
+                    'role' => 'R1',
+                ],
+                [
+                    'file' => $file2,
+                    'start_sec' => 2,
+                    'end_sec' => 4,
+                    'note' => 'second',
+                    'bundle_key' => 'B2',
+                    'role' => 'R2',
+                ],
+            ],
+        ];
+
+        $page = new VideoUpload();
+        $page->form = new class($state)
+        {
+            public function __construct(private array $state) {}
+
+            public function getState(): array
+            {
+                return $this->state;
+            }
+
+            public function fill(): void
+            {
+            }
+        };
+
+        $page->submit();
+
+        Bus::assertDispatchedTimes(ProcessUploadedVideo::class, 2);
+        Bus::assertDispatched(ProcessUploadedVideo::class, function (ProcessUploadedVideo $job) use ($user, $file1) {
+            return $job->originalName === $file1->getClientOriginalName()
+                && $job->ext === $file1->getClientOriginalExtension()
+                && $job->start === 1
+                && $job->end === 3
+                && $job->note === 'first'
+                && $job->bundleKey === 'B1'
+                && $job->role === 'R1'
+                && $job->submittedBy === $user->name;
+        });
+        Bus::assertDispatched(ProcessUploadedVideo::class, function (ProcessUploadedVideo $job) use ($user, $file2) {
+            return $job->originalName === $file2->getClientOriginalName()
+                && $job->ext === $file2->getClientOriginalExtension()
+                && $job->start === 2
+                && $job->end === 4
+                && $job->note === 'second'
+                && $job->bundleKey === 'B2'
+                && $job->role === 'R2'
+                && $job->submittedBy === $user->name;
+        });
+
+        @unlink($path1);
+        @unlink($path2);
+    }
+}

--- a/tests/Feature/Jobs/ProcessUploadedVideoTest.php
+++ b/tests/Feature/Jobs/ProcessUploadedVideoTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Jobs;
+
+use App\Facades\Cfg;
+use App\Jobs\ProcessUploadedVideo;
+use App\Models\Video;
+use App\Services\IngestScanner;
+use Tests\DatabaseTestCase;
+
+final class ProcessUploadedVideoTest extends DatabaseTestCase
+{
+    public function testHandleProcessesFileAndCreatesClip(): void
+    {
+        Cfg::set('default_file_system', 'testdisk', 'default');
+
+        $path = storage_path('app/test.mp4');
+        file_put_contents($path, 'video-data');
+        $hash = hash_file('sha256', $path);
+
+        $video = Video::factory()->create([
+            'hash' => $hash,
+            'ext' => 'mp4',
+            'bytes' => filesize($path),
+            'path' => 'videos/'.$hash.'.mp4',
+            'disk' => 'local',
+        ]);
+
+        $scanner = app(IngestScanner::class);
+
+        $job = new ProcessUploadedVideo(
+            path: $path,
+            originalName: 'clip.mp4',
+            ext: 'mp4',
+            start: 5,
+            end: 12,
+            submittedBy: 'alice',
+            note: 'note here',
+            bundleKey: 'bundleA',
+            role: 'driver',
+        );
+
+        $job->handle($scanner);
+
+        $this->assertFileDoesNotExist($path);
+
+        $this->assertDatabaseHas('clips', [
+            'video_id' => $video->id,
+            'start_sec' => 5,
+            'end_sec' => 12,
+            'submitted_by' => 'alice',
+            'note' => 'note here',
+            'bundle_key' => 'bundleA',
+            'role' => 'driver',
+        ]);
+
+        if (file_exists($path)) {
+            @unlink($path);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- allow uploading multiple videos at once with clip range selection
- capture note, role and bundle id for each clip and process them asynchronously
- persist bundle metadata when creating clips via job
- fetch `default_file_system` from the `default` category

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68aba3b156b48329b48d8ef3569f5d16