### PR TITLE
feat: migrate preview service to laravel-ffmpeg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Multi-factor authentication (MFA)** with support for authenticator apps (TOTP) and one-time codes via email.
 - **Web-based video upload** in the admin UI, complementing existing ingest workflows.
+- Config table now supports a `selectable` JSON column so settings can offer predefined choices.
+- New **FFMPEG** configuration category seeds codec, preset and parameter defaults for preview generation.
+- Admin UI renders selectable values for JSON-based settings as multi-select inputs.
 
 ### Changed
 
 - **Backend upgraded to Filament v4** (UI components and pages migrated).
+- Preview generation now uses the `pbmedia/laravel-ffmpeg` package and reads all codec options from the database.
 
 ### Breaking
 

--- a/app/Filament/Resources/Configs/ConfigResource.php
+++ b/app/Filament/Resources/Configs/ConfigResource.php
@@ -41,11 +41,14 @@ class ConfigResource extends Resource
                 ->default('string')
                 ->reactive()
                 ->dehydrated(false),
+            Hidden::make('selectable')
+                ->default(fn(?Config $record) => $record?->selectable)
+                ->dehydrated(false),
             Placeholder::make('cast_type_display')
                 ->label('Cast Type')
                 ->content(fn(Get $get) => ConfigFilamentMapper::typeLabel($get('cast_type'))),
             Group::make()
-                ->schema(fn(Get $get) => ConfigFilamentMapper::valueFormComponents($get('cast_type')))
+                ->schema(fn(Get $get) => ConfigFilamentMapper::valueFormComponents($get('cast_type'), $get('selectable')))
                 ->columnSpanFull(),
         ]);
     }

--- a/app/Filament/Support/ConfigFilamentMapper.php
+++ b/app/Filament/Support/ConfigFilamentMapper.php
@@ -8,6 +8,7 @@ use Filament\Forms\Components\Toggle;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\KeyValue;
 use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\Select;
 use App\Enum\ConfigTypeEnum;
 use App\Support\ConfigCaster;
 use Filament\Forms;
@@ -22,11 +23,28 @@ class ConfigFilamentMapper
      * based on the provided cast type (aliases resolved by ConfigCaster).
      *
      * @param  string|null  $castType
+     * @param  array<int, string>|null $selectable
      * @return array<int, \Filament\Schemas\Components\Component>
      */
-    public static function valueFormComponents(?string $castType): array
+    public static function valueFormComponents(?string $castType, ?array $selectable = null): array
     {
-        return match (ConfigCaster::normalize($castType)) {
+        $type = ConfigCaster::normalize($castType);
+
+        if ($selectable !== null && $selectable !== []) {
+            $options = array_combine($selectable, $selectable);
+            $field = Select::make('value')
+                ->label('Value')
+                ->required()
+                ->options($options);
+
+            if ($type === ConfigTypeEnum::JSON) {
+                $field->multiple();
+            }
+
+            return [$field];
+        }
+
+        return match ($type) {
             ConfigTypeEnum::BOOL => [
                 Toggle::make('value')
                     ->label('Value')

--- a/app/Models/Config.php
+++ b/app/Models/Config.php
@@ -16,10 +16,11 @@ class Config extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['key', 'value', 'is_visible', 'cast_type', 'config_category_id'];
+    protected $fillable = ['key', 'value', 'selectable', 'is_visible', 'cast_type', 'config_category_id'];
 
     protected $casts = [
         'is_visible' => 'bool',
+        'selectable' => 'array',
     ];
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "laravel/reverb": "^1.0",
     "laravel/tinker": "^2.10.1",
     "maennchen/zipstream-php": "^3.2",
+    "pbmedia/laravel-ffmpeg": "^8.0",
     "spatie/flysystem-dropbox": "^3.0",
     "tapp/filament-maillog": "^2.0"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "670f1345f0195a6a797069cb2a7d0fc4",
+    "content-hash": "881f155a00463f0af294e8c022edeae0",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -4718,6 +4718,174 @@
             "time": "2024-09-04T12:51:01+00:00"
         },
         {
+            "name": "pbmedia/laravel-ffmpeg",
+            "version": "8.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/protonemedia/laravel-ffmpeg.git",
+                "reference": "596804eee95b97bca146653770e7622159976bb1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/protonemedia/laravel-ffmpeg/zipball/596804eee95b97bca146653770e7622159976bb1",
+                "reference": "596804eee95b97bca146653770e7622159976bb1",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^10.0|^11.0|^12.0",
+                "php": "^8.1|^8.2|^8.3|^8.4",
+                "php-ffmpeg/php-ffmpeg": "^1.2",
+                "ramsey/collection": "^2.0"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.21",
+                "league/flysystem-memory": "^3.10",
+                "mockery/mockery": "^1.4.4",
+                "nesbot/carbon": "^2.66|^3.0",
+                "orchestra/testbench": "^8.0|^9.0|^10.0",
+                "phpunit/phpunit": "^10.4|^11.5.3",
+                "spatie/image": "^2.2|^3.3",
+                "spatie/phpunit-snapshot-assertions": "^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "FFMpeg": "ProtoneMedia\\LaravelFFMpeg\\Support\\FFMpeg"
+                    },
+                    "providers": [
+                        "ProtoneMedia\\LaravelFFMpeg\\Support\\ServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "ProtoneMedia\\LaravelFFMpeg\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Pascal Baljet",
+                    "email": "pascal@protone.media",
+                    "homepage": "https://protone.media",
+                    "role": "Developer"
+                }
+            ],
+            "description": "FFMpeg for Laravel",
+            "homepage": "https://github.com/protonemedia/laravel-ffmpeg",
+            "keywords": [
+                "ffmpeg",
+                "laravel",
+                "laravel-ffmpeg",
+                "protone media",
+                "protonemedia"
+            ],
+            "support": {
+                "issues": "https://github.com/protonemedia/laravel-ffmpeg/issues",
+                "source": "https://github.com/protonemedia/laravel-ffmpeg/tree/8.7.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/pascalbaljet",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-04-01T21:11:35+00:00"
+        },
+        {
+            "name": "php-ffmpeg/php-ffmpeg",
+            "version": "v1.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHP-FFMpeg/PHP-FFMpeg.git",
+                "reference": "8e74bdc07ad200da7a6cfb21ec2652875e4368e0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHP-FFMpeg/PHP-FFMpeg/zipball/8e74bdc07ad200da7a6cfb21ec2652875e4368e0",
+                "reference": "8e74bdc07ad200da7a6cfb21ec2652875e4368e0",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0",
+                "php": "^8.0 || ^8.1 || ^8.2 || ^8.3 || ^8.4",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
+                "spatie/temporary-directory": "^2.0",
+                "symfony/cache": "^5.4 || ^6.0 || ^7.0",
+                "symfony/process": "^5.4 || ^6.0 || ^7.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.5",
+                "phpunit/phpunit": "^9.5.10 || ^10.0"
+            },
+            "suggest": {
+                "php-ffmpeg/extras": "A compilation of common audio & video drivers for PHP-FFMpeg"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "FFMpeg\\": "src/FFMpeg",
+                    "Alchemy\\BinaryDriver\\": "src/Alchemy/BinaryDriver"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Romain Neutron",
+                    "email": "imprec@gmail.com",
+                    "homepage": "http://www.lickmychip.com/"
+                },
+                {
+                    "name": "Phraseanet Team",
+                    "email": "info@alchemy.fr",
+                    "homepage": "http://www.phraseanet.com/"
+                },
+                {
+                    "name": "Patrik Karisch",
+                    "email": "patrik@karisch.guru",
+                    "homepage": "http://www.karisch.guru"
+                },
+                {
+                    "name": "Romain Biard",
+                    "email": "romain.biard@gmail.com",
+                    "homepage": "https://www.strime.io/"
+                },
+                {
+                    "name": "Jens Hausdorf",
+                    "email": "hello@jens-hausdorf.de",
+                    "homepage": "https://jens-hausdorf.de"
+                },
+                {
+                    "name": "Pascal Baljet",
+                    "email": "pascal@protone.media",
+                    "homepage": "https://protone.media"
+                }
+            ],
+            "description": "FFMpeg PHP, an Object Oriented library to communicate with AVconv / ffmpeg",
+            "keywords": [
+                "audio",
+                "audio processing",
+                "avconv",
+                "avprobe",
+                "ffmpeg",
+                "ffprobe",
+                "video",
+                "video processing"
+            ],
+            "support": {
+                "issues": "https://github.com/PHP-FFMpeg/PHP-FFMpeg/issues",
+                "source": "https://github.com/PHP-FFMpeg/PHP-FFMpeg/tree/v1.3.2"
+            },
+            "time": "2025-04-01T20:36:46+00:00"
+        },
+        {
             "name": "phpoption/phpoption",
             "version": "1.9.4",
             "source": {
@@ -4910,6 +5078,55 @@
                 "source": "https://github.com/antonioribeiro/google2fa-qrcode/tree/v3.0.0"
             },
             "time": "2021-08-15T12:53:48+00:00"
+        },
+        {
+            "name": "psr/cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/3.0.0"
+            },
+            "time": "2021-02-03T23:26:27+00:00"
         },
         {
             "name": "psr/clock",
@@ -6731,6 +6948,245 @@
                 }
             ],
             "time": "2025-02-21T14:16:57+00:00"
+        },
+        {
+            "name": "spatie/temporary-directory",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/temporary-directory.git",
+                "reference": "580eddfe9a0a41a902cac6eeb8f066b42e65a32b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/temporary-directory/zipball/580eddfe9a0a41a902cac6eeb8f066b42e65a32b",
+                "reference": "580eddfe9a0a41a902cac6eeb8f066b42e65a32b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\TemporaryDirectory\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Vanderbist",
+                    "email": "alex@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Easily create, use and destroy temporary directories",
+            "homepage": "https://github.com/spatie/temporary-directory",
+            "keywords": [
+                "php",
+                "spatie",
+                "temporary-directory"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/temporary-directory/issues",
+                "source": "https://github.com/spatie/temporary-directory/tree/2.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-01-13T13:04:43+00:00"
+        },
+        {
+            "name": "symfony/cache",
+            "version": "v7.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/cache.git",
+                "reference": "6621a2bee5373e3e972b2ae5dbedd5ac899d8cb6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/6621a2bee5373e3e972b2ae5dbedd5ac899d8cb6",
+                "reference": "6621a2bee5373e3e972b2ae5dbedd5ac899d8cb6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/cache": "^2.0|^3.0",
+                "psr/log": "^1.1|^2|^3",
+                "symfony/cache-contracts": "^3.6",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/var-exporter": "^6.4|^7.0"
+            },
+            "conflict": {
+                "doctrine/dbal": "<3.6",
+                "symfony/dependency-injection": "<6.4",
+                "symfony/http-kernel": "<6.4",
+                "symfony/var-dumper": "<6.4"
+            },
+            "provide": {
+                "psr/cache-implementation": "2.0|3.0",
+                "psr/simple-cache-implementation": "1.0|2.0|3.0",
+                "symfony/cache-implementation": "1.1|2.0|3.0"
+            },
+            "require-dev": {
+                "cache/integration-tests": "dev-master",
+                "doctrine/dbal": "^3.6|^4",
+                "predis/predis": "^1.1|^2.0",
+                "psr/simple-cache": "^1.0|^2.0|^3.0",
+                "symfony/clock": "^6.4|^7.0",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/filesystem": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/messenger": "^6.4|^7.0",
+                "symfony/var-dumper": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Cache\\": ""
+                },
+                "classmap": [
+                    "Traits/ValueWrapper.php"
+                ],
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides extended PSR-6, PSR-16 (and tags) implementations",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "caching",
+                "psr6"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/cache/tree/v7.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-30T17:13:41+00:00"
+        },
+        {
+            "name": "symfony/cache-contracts",
+            "version": "v3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/cache-contracts.git",
+                "reference": "5d68a57d66910405e5c0b63d6f0af941e66fc868"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/5d68a57d66910405e5c0b63d6f0af941e66fc868",
+                "reference": "5d68a57d66910405e5c0b63d6f0af941e66fc868",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/cache": "^3.0"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Cache\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to caching",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/cache-contracts/tree/v3.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-03-13T15:25:07+00:00"
         },
         {
             "name": "symfony/clock",
@@ -9274,6 +9730,87 @@
                 }
             ],
             "time": "2025-07-29T20:02:46+00:00"
+        },
+        {
+            "name": "symfony/var-exporter",
+            "version": "v7.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-exporter.git",
+                "reference": "05b3e90654c097817325d6abd284f7938b05f467"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/05b3e90654c097817325d6abd284f7938b05f467",
+                "reference": "05b3e90654c097817325d6abd284f7938b05f467",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "require-dev": {
+                "symfony/property-access": "^6.4|^7.0",
+                "symfony/serializer": "^6.4|^7.0",
+                "symfony/var-dumper": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\VarExporter\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows exporting any serializable PHP data structure to plain PHP code",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "clone",
+                "construct",
+                "export",
+                "hydrate",
+                "instantiate",
+                "lazy-loading",
+                "proxy",
+                "serialize"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/var-exporter/tree/v7.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-10T08:47:49+00:00"
         },
         {
             "name": "tapp/filament-maillog",

--- a/database/migrations/2025_08_28_201046_add_selectable_to_configs_table.php
+++ b/database/migrations/2025_08_28_201046_add_selectable_to_configs_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('configs', function (Blueprint $table) {
+            $table->json('selectable')->nullable()->after('value');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('configs', function (Blueprint $table) {
+            $table->dropColumn('selectable');
+        });
+    }
+};

--- a/database/migrations/2025_08_28_201048_add_ffmpeg_config_entries.php
+++ b/database/migrations/2025_08_28_201048_add_ffmpeg_config_entries.php
@@ -1,0 +1,104 @@
+<?php
+
+use Carbon\Carbon;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $timestamp = Carbon::now()->format('Y-m-d H:i:s');
+
+        $categoryId = DB::table('config_categories')->insertGetId([
+            'slug' => 'ffmpeg',
+            'name' => 'FFMPEG',
+            'is_visible' => true,
+            'created_at' => $timestamp,
+            'updated_at' => $timestamp,
+        ]);
+
+        DB::table('configs')->insert([
+            [
+                'key' => 'ffmpeg_bin',
+                'value' => '',
+                'selectable' => null,
+                'cast_type' => 'string',
+                'is_visible' => 1,
+                'config_category_id' => $categoryId,
+                'created_at' => $timestamp,
+                'updated_at' => $timestamp,
+            ],
+            [
+                'key' => 'ffmpeg_video_codec',
+                'value' => 'libx264',
+                'selectable' => json_encode(['libx264', 'libx265', 'libvpx-vp9']),
+                'cast_type' => 'string',
+                'is_visible' => 1,
+                'config_category_id' => $categoryId,
+                'created_at' => $timestamp,
+                'updated_at' => $timestamp,
+            ],
+            [
+                'key' => 'ffmpeg_audio_codec',
+                'value' => 'aac',
+                'selectable' => json_encode(['aac', 'libmp3lame', 'libvorbis']),
+                'cast_type' => 'string',
+                'is_visible' => 1,
+                'config_category_id' => $categoryId,
+                'created_at' => $timestamp,
+                'updated_at' => $timestamp,
+            ],
+            [
+                'key' => 'ffmpeg_preset',
+                'value' => 'veryfast',
+                'selectable' => json_encode(['ultrafast','superfast','veryfast','faster','fast','medium','slow','slower','veryslow','placebo']),
+                'cast_type' => 'string',
+                'is_visible' => 1,
+                'config_category_id' => $categoryId,
+                'created_at' => $timestamp,
+                'updated_at' => $timestamp,
+            ],
+            [
+                'key' => 'ffmpeg_crf',
+                'value' => '28',
+                'selectable' => null,
+                'cast_type' => 'int',
+                'is_visible' => 1,
+                'config_category_id' => $categoryId,
+                'created_at' => $timestamp,
+                'updated_at' => $timestamp,
+            ],
+            [
+                'key' => 'ffmpeg_video_args',
+                'value' => json_encode([]),
+                'selectable' => null,
+                'cast_type' => 'json',
+                'is_visible' => 1,
+                'config_category_id' => $categoryId,
+                'created_at' => $timestamp,
+                'updated_at' => $timestamp,
+            ],
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::table('configs')->whereIn('key', [
+            'ffmpeg_bin',
+            'ffmpeg_video_codec',
+            'ffmpeg_audio_codec',
+            'ffmpeg_preset',
+            'ffmpeg_crf',
+            'ffmpeg_video_args',
+        ])->delete();
+
+        DB::table('config_categories')->where('slug', 'ffmpeg')->delete();
+    }
+};

--- a/lang/de/configs.php
+++ b/lang/de/configs.php
@@ -16,5 +16,11 @@ return [
         'assign_expire_cooldown_days' => 'Cooldown-Tage je (channel, video)',
         'ingest_inbox_absolute_path' => 'Inbox-Pfad für Videos (absolut)',
         'post_expiry_retention_weeks' => 'Aufbewahrungsfrist nach Ablauf (in Wochen)',
+        'ffmpeg_bin' => 'Pfad zur FFmpeg-Binärdatei (z.B. /usr/bin/ffmpeg)',
+        'ffmpeg_video_codec' => 'Video-Codec für Previews (z.B. libx264)',
+        'ffmpeg_audio_codec' => 'Audio-Codec für Previews (z.B. aac)',
+        'ffmpeg_preset' => 'FFmpeg-Preset für Geschwindigkeit/Qualität (z.B. medium)',
+        'ffmpeg_crf' => 'CRF-Qualitätswert 0–51 (z.B. 23)',
+        'ffmpeg_video_args' => 'Zusätzliche FFmpeg-Optionen (z.B. -movflags +faststart)',
     ],
 ];

--- a/tests/Feature/Console/IngestScanTest.php
+++ b/tests/Feature/Console/IngestScanTest.php
@@ -9,6 +9,7 @@ use App\Models\Video;
 use Illuminate\Console\Command;
 use Tests\DatabaseTestCase;
 use Tests\Helper\FfmpegBinaryFaker;
+use App\Facades\Cfg;
 
 /**
  * Feature tests for the "ingest:scan" console command with the real IngestScanner.
@@ -23,9 +24,8 @@ final class IngestScanTest extends DatabaseTestCase
     private function useFakeFfmpegSuccess(): string
     {
         $bin = (new FfmpegBinaryFaker())->success('FAKEMP4');
-        config()->set('services.ffmpeg.bin', $bin);
-        config()->set('services.ffmpeg.timeout', 30);
-        config()->set('services.ffmpeg.video_args', []); // keep args simple
+        Cfg::set('ffmpeg_bin', $bin, 'ffmpeg');
+        Cfg::set('ffmpeg_video_args', [], 'ffmpeg', 'json'); // keep args simple
         return $bin;
     }
 


### PR DESCRIPTION
## Summary
- replace manual ffmpeg calls with laravel-ffmpeg
- install pbmedia/laravel-ffmpeg package
- generate fake mp4 data during tests instead of storing binary fixtures
- translate PreviewService comments to English and ensure preview directory exists
- add selectable JSON column for configs and seed ffmpeg defaults
- pull ffmpeg options from database configs
- render selectable options for JSON config entries as multi-select in Filament UI
- add German descriptions for ffmpeg config keys with user-oriented examples
- document all changes for version 3.0.0 in the changelog

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68b0934bba308329a73c98eb50aaff97