### PR TITLE
feat: add statistics widgets

### DIFF
--- a/app/Filament/Pages/Statistics.php
+++ b/app/Filament/Pages/Statistics.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use Filament\Pages\Page;
+
+class Statistics extends Page
+{
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-chart-bar';
+
+    protected static ?string $navigationLabel = 'Statistics';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Statistics';
+
+    protected static ?string $title = 'Statistics';
+
+    protected string $view = 'filament.pages.statistics';
+
+    public string $tab = 'assignments';
+}

--- a/app/Filament/Widgets/DownloadDelayChart.php
+++ b/app/Filament/Widgets/DownloadDelayChart.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use Carbon\Carbon;
+use Filament\Forms\Components\DatePicker;
+use Filament\Schemas\Schema;
+use Filament\Widgets\ChartWidget;
+use Illuminate\Support\Facades\DB;
+
+class DownloadDelayChart extends ChartWidget
+{
+    protected ?string $heading = 'Download Delay';
+
+    public ?array $filters = [];
+
+    public function mount(): void
+    {
+        $this->filters = [
+            'from' => now()->subMonth()->toDateString(),
+            'to' => now()->toDateString(),
+        ];
+
+        parent::mount();
+    }
+
+    public function filtersSchema(Schema $schema): Schema
+    {
+        return $schema
+            ->columns(2)
+            ->components([
+                DatePicker::make('from')->label('Von')->required(),
+                DatePicker::make('to')->label('Bis')->required(),
+            ]);
+    }
+
+    protected function getData(): array
+    {
+        $from = $this->filters['from'] ?? now()->subMonth()->toDateString();
+        $to = $this->filters['to'] ?? now()->toDateString();
+
+        $rows = DB::table('downloads')
+            ->join('assignments', 'downloads.assignment_id', '=', 'assignments.id')
+            ->whereBetween('downloads.downloaded_at', [$from, $to])
+            ->whereNotNull('assignments.last_notified_at')
+            ->get(['downloads.downloaded_at', 'assignments.last_notified_at']);
+
+        $diffs = [];
+        foreach ($rows as $row) {
+            $downloadedAt = Carbon::parse($row->downloaded_at);
+            $notifiedAt = Carbon::parse($row->last_notified_at);
+            $diffs[] = $notifiedAt->diffInMinutes($downloadedAt);
+        }
+
+        $avg = count($diffs) ? round(array_sum($diffs) / count($diffs), 2) : 0;
+        sort($diffs);
+        $median = 0;
+        $count = count($diffs);
+        if ($count) {
+            $middle = intdiv($count, 2);
+            if ($count % 2) {
+                $median = $diffs[$middle];
+            } else {
+                $median = round(($diffs[$middle - 1] + $diffs[$middle]) / 2, 2);
+            }
+        }
+
+        return [
+            'datasets' => [
+                [
+                    'label' => 'Minutes',
+                    'data' => [$avg, $median],
+                ],
+            ],
+            'labels' => ['Average', 'Median'],
+        ];
+    }
+
+    protected function getType(): string
+    {
+        return 'bar';
+    }
+}

--- a/app/Filament/Widgets/DownloadsPerHourChart.php
+++ b/app/Filament/Widgets/DownloadsPerHourChart.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use Filament\Forms\Components\DatePicker;
+use Filament\Schemas\Schema;
+use Filament\Widgets\ChartWidget;
+use Illuminate\Support\Facades\DB;
+
+class DownloadsPerHourChart extends ChartWidget
+{
+    protected ?string $heading = 'Downloads per Hour';
+
+    public ?array $filters = [];
+
+    public function mount(): void
+    {
+        $this->filters = [
+            'from' => now()->subMonth()->toDateString(),
+            'to' => now()->toDateString(),
+        ];
+
+        parent::mount();
+    }
+
+    public function filtersSchema(Schema $schema): Schema
+    {
+        return $schema
+            ->columns(2)
+            ->components([
+                DatePicker::make('from')->label('Von')->required(),
+                DatePicker::make('to')->label('Bis')->required(),
+            ]);
+    }
+
+    protected function getData(): array
+    {
+        $from = $this->filters['from'] ?? now()->subMonth()->toDateString();
+        $to = $this->filters['to'] ?? now()->toDateString();
+
+        $rows = DB::table('downloads')
+            ->whereBetween('downloads.downloaded_at', [$from, $to])
+            ->select(DB::raw('HOUR(downloads.downloaded_at) as hour'), DB::raw('count(*) as count'))
+            ->groupBy('hour')
+            ->orderBy('hour')
+            ->get();
+
+        $data = array_fill(0, 24, 0);
+        foreach ($rows as $row) {
+            $data[(int) $row->hour] = (int) $row->count;
+        }
+
+        return [
+            'datasets' => [
+                [
+                    'label' => 'Downloads',
+                    'data' => array_values($data),
+                ],
+            ],
+            'labels' => array_map(fn ($h) => str_pad((string) $h, 2, '0', STR_PAD_LEFT), range(0, 23)),
+        ];
+    }
+
+    protected function getType(): string
+    {
+        return 'line';
+    }
+}

--- a/app/Filament/Widgets/UploadStatsChart.php
+++ b/app/Filament/Widgets/UploadStatsChart.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\Clip;
+use Filament\Forms\Components\DatePicker;
+use Filament\Schemas\Schema;
+use Filament\Widgets\ChartWidget;
+use Illuminate\Support\Facades\DB;
+
+class UploadStatsChart extends ChartWidget
+{
+    protected ?string $heading = 'Uploads per Submitter';
+
+    public ?array $filters = [];
+
+    public function mount(): void
+    {
+        $this->filters = [
+            'from' => now()->subMonth()->toDateString(),
+            'to' => now()->toDateString(),
+        ];
+
+        parent::mount();
+    }
+
+    public function filtersSchema(Schema $schema): Schema
+    {
+        return $schema
+            ->columns(2)
+            ->components([
+                DatePicker::make('from')->label('Von')->required(),
+                DatePicker::make('to')->label('Bis')->required(),
+            ]);
+    }
+
+    protected function getData(): array
+    {
+        $from = $this->filters['from'] ?? now()->subMonth()->toDateString();
+        $to = $this->filters['to'] ?? now()->toDateString();
+
+        $rows = Clip::query()
+            ->whereBetween('created_at', [$from, $to])
+            ->select('submitted_by', DB::raw('count(*) as count'))
+            ->groupBy('submitted_by')
+            ->orderByDesc('count')
+            ->get();
+
+        $labels = $rows->map(fn($row) => $row->submitted_by ?? 'Unknown')->all();
+        $data = $rows->map(fn($row) => (int) $row->count)->all();
+
+        return [
+            'datasets' => [
+                [
+                    'label' => 'Uploads',
+                    'data' => $data,
+                ],
+            ],
+            'labels' => $labels,
+        ];
+    }
+
+    protected function getType(): string
+    {
+        return 'pie';
+    }
+}

--- a/resources/views/filament/pages/statistics.blade.php
+++ b/resources/views/filament/pages/statistics.blade.php
@@ -1,0 +1,26 @@
+<x-filament-panels::page>
+    <x-filament::tabs>
+        <x-filament::tabs.item wire:click="$set('tab', 'assignments')" :active="$tab === 'assignments'">
+            Assignments
+        </x-filament::tabs.item>
+        <x-filament::tabs.item wire:click="$set('tab', 'uploads')" :active="$tab === 'uploads'">
+            Uploads
+        </x-filament::tabs.item>
+        <x-filament::tabs.item wire:click="$set('tab', 'downloads')" :active="$tab === 'downloads'">
+            Downloads
+        </x-filament::tabs.item>
+    </x-filament::tabs>
+
+    <div class="mt-6 space-y-6">
+        @if ($tab === 'assignments')
+            @livewire(\App\Filament\Widgets\AssignmentStatusChart::class)
+        @elseif ($tab === 'uploads')
+            @livewire(\App\Filament\Widgets\UploadStatsChart::class)
+        @elseif ($tab === 'downloads')
+            <div class="grid gap-6">
+                @livewire(\App\Filament\Widgets\DownloadDelayChart::class)
+                @livewire(\App\Filament\Widgets\DownloadsPerHourChart::class)
+            </div>
+        @endif
+    </div>
+</x-filament-panels::page>


### PR DESCRIPTION
## Summary
- refactor statistics page into chart widgets
- visualize assignments by channel, uploads per submitter, and download timings
- add statistics page with tabbed chart widgets

## Testing
- `composer test` *(fails: script @php artisan test handling the test event returned with error code 1)*
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68b0a964e7a48329bed25a53d79afb19