### PR TITLE
feat: add statistics widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New **FFMPEG** configuration category seeds codec, preset and parameter defaults for preview generation.
 - Admin UI renders selectable values for JSON-based settings as multi-select inputs.
 
+- Admin statistics page with chart widgets for assignments, uploads, and download activity.
+
 ### Changed
 
 - **Backend upgraded to Filament v4** (UI components and pages migrated).
 - Preview generation now uses the `pbmedia/laravel-ffmpeg` package and reads all codec options from the database.
+- Statistics charts now display distinct colors for clearer visual separation.
 
 ### Breaking
 

--- a/app/Filament/Pages/Statistics.php
+++ b/app/Filament/Pages/Statistics.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use Filament\Pages\Page;
+
+class Statistics extends Page
+{
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-chart-bar';
+
+    protected static ?string $navigationLabel = 'Statistics';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Statistics';
+
+    protected static ?string $title = 'Statistics';
+
+    protected string $view = 'filament.pages.statistics';
+
+    public string $tab = 'assignments';
+}

--- a/app/Filament/Widgets/AssignmentStatusChart.php
+++ b/app/Filament/Widgets/AssignmentStatusChart.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\Assignment;
+use Filament\Forms\Components\DatePicker;
+use Filament\Schemas\Schema;
+use Filament\Widgets\ChartWidget;
+use Illuminate\Support\Facades\DB;
+
+class AssignmentStatusChart extends ChartWidget
+{
+    protected ?string $heading = 'Assignments by Channel';
+
+    public ?array $filters = [];
+
+    public function mount(): void
+    {
+        $this->filters = [
+            'from' => now()->subMonth()->toDateString(),
+            'to' => now()->toDateString(),
+        ];
+
+        parent::mount();
+    }
+
+    public function filtersSchema(Schema $schema): Schema
+    {
+        return $schema
+            ->columns(2)
+            ->components([
+                DatePicker::make('from')->label('Von')->required(),
+                DatePicker::make('to')->label('Bis')->required(),
+            ]);
+    }
+
+    protected function getData(): array
+    {
+        $from = $this->filters['from'] ?? now()->subMonth()->toDateString();
+        $to = $this->filters['to'] ?? now()->toDateString();
+
+        $rows = Assignment::query()
+            ->join('channels', 'assignments.channel_id', '=', 'channels.id')
+            ->whereBetween('assignments.created_at', [$from, $to])
+            ->select('channels.name as channel', DB::raw('status, count(*) as count'))
+            ->groupBy('channels.name', 'status')
+            ->get();
+
+        $stats = [];
+        foreach ($rows as $row) {
+            $stats[$row->channel][$row->status] = (int) $row->count;
+            $stats[$row->channel]['total'] = ($stats[$row->channel]['total'] ?? 0) + (int) $row->count;
+        }
+
+        $labels = array_keys($stats);
+
+        $colors = [
+            'picked_up' => '#10b981',
+            'notified' => '#3b82f6',
+            'rejected' => '#ef4444',
+        ];
+
+        $datasets = [];
+        foreach (['picked_up', 'notified', 'rejected'] as $status) {
+            $color = $colors[$status];
+            $datasets[] = [
+                'label' => ucfirst(str_replace('_', ' ', $status)),
+                'data' => array_map(function ($channel) use ($stats, $status) {
+                    $total = $stats[$channel]['total'] ?: 1;
+                    $count = $stats[$channel][$status] ?? 0;
+                    return round($count / $total * 100, 2);
+                }, $labels),
+                'backgroundColor' => $color,
+                'borderColor' => $color,
+            ];
+        }
+
+        return [
+            'datasets' => $datasets,
+            'labels' => $labels,
+        ];
+    }
+
+    protected function getType(): string
+    {
+        return 'bar';
+    }
+}

--- a/app/Filament/Widgets/DownloadDelayChart.php
+++ b/app/Filament/Widgets/DownloadDelayChart.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use Carbon\Carbon;
+use Filament\Forms\Components\DatePicker;
+use Filament\Schemas\Schema;
+use Filament\Widgets\ChartWidget;
+use Illuminate\Support\Facades\DB;
+
+class DownloadDelayChart extends ChartWidget
+{
+    protected ?string $heading = 'Download Delay';
+
+    public ?array $filters = [];
+
+    public function mount(): void
+    {
+        $this->filters = [
+            'from' => now()->subMonth()->toDateString(),
+            'to' => now()->toDateString(),
+        ];
+
+        parent::mount();
+    }
+
+    public function filtersSchema(Schema $schema): Schema
+    {
+        return $schema
+            ->columns(2)
+            ->components([
+                DatePicker::make('from')->label('Von')->required(),
+                DatePicker::make('to')->label('Bis')->required(),
+            ]);
+    }
+
+    protected function getData(): array
+    {
+        $from = $this->filters['from'] ?? now()->subMonth()->toDateString();
+        $to = $this->filters['to'] ?? now()->toDateString();
+
+        $rows = DB::table('downloads')
+            ->join('assignments', 'downloads.assignment_id', '=', 'assignments.id')
+            ->whereBetween('downloads.downloaded_at', [$from, $to])
+            ->whereNotNull('assignments.last_notified_at')
+            ->get(['downloads.downloaded_at', 'assignments.last_notified_at']);
+
+        $diffs = [];
+        foreach ($rows as $row) {
+            $downloadedAt = Carbon::parse($row->downloaded_at);
+            $notifiedAt = Carbon::parse($row->last_notified_at);
+            $diffs[] = $notifiedAt->diffInMinutes($downloadedAt);
+        }
+
+        $avg = count($diffs) ? round(array_sum($diffs) / count($diffs), 2) : 0;
+        sort($diffs);
+        $median = 0;
+        $count = count($diffs);
+        if ($count) {
+            $middle = intdiv($count, 2);
+            if ($count % 2) {
+                $median = $diffs[$middle];
+            } else {
+                $median = round(($diffs[$middle - 1] + $diffs[$middle]) / 2, 2);
+            }
+        }
+
+        return [
+            'datasets' => [
+                [
+                    'label' => 'Minutes',
+                    'data' => [$avg, $median],
+                    'backgroundColor' => ['#3b82f6', '#f59e0b'],
+                    'borderColor' => ['#3b82f6', '#f59e0b'],
+                ],
+            ],
+            'labels' => ['Average', 'Median'],
+        ];
+    }
+
+    protected function getType(): string
+    {
+        return 'bar';
+    }
+}

--- a/app/Filament/Widgets/DownloadsPerHourChart.php
+++ b/app/Filament/Widgets/DownloadsPerHourChart.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use Filament\Forms\Components\DatePicker;
+use Filament\Schemas\Schema;
+use Filament\Widgets\ChartWidget;
+use Illuminate\Support\Facades\DB;
+
+class DownloadsPerHourChart extends ChartWidget
+{
+    protected ?string $heading = 'Downloads per Hour';
+
+    public ?array $filters = [];
+
+    public function mount(): void
+    {
+        $this->filters = [
+            'from' => now()->subMonth()->toDateString(),
+            'to' => now()->toDateString(),
+        ];
+
+        parent::mount();
+    }
+
+    public function filtersSchema(Schema $schema): Schema
+    {
+        return $schema
+            ->columns(2)
+            ->components([
+                DatePicker::make('from')->label('Von')->required(),
+                DatePicker::make('to')->label('Bis')->required(),
+            ]);
+    }
+
+    protected function getData(): array
+    {
+        $from = $this->filters['from'] ?? now()->subMonth()->toDateString();
+        $to = $this->filters['to'] ?? now()->toDateString();
+
+        $rows = DB::table('downloads')
+            ->whereBetween('downloads.downloaded_at', [$from, $to])
+            ->select(DB::raw('HOUR(downloads.downloaded_at) as hour'), DB::raw('count(*) as count'))
+            ->groupBy('hour')
+            ->orderBy('hour')
+            ->get();
+
+        $data = array_fill(0, 24, 0);
+        foreach ($rows as $row) {
+            $data[(int) $row->hour] = (int) $row->count;
+        }
+
+        return [
+            'datasets' => [
+                [
+                    'label' => 'Downloads',
+                    'data' => array_values($data),
+                    'borderColor' => '#8b5cf6',
+                    'backgroundColor' => '#8b5cf6',
+                ],
+            ],
+            'labels' => array_map(fn ($h) => str_pad((string) $h, 2, '0', STR_PAD_LEFT), range(0, 23)),
+        ];
+    }
+
+    protected function getType(): string
+    {
+        return 'line';
+    }
+}

--- a/app/Filament/Widgets/UploadStatsChart.php
+++ b/app/Filament/Widgets/UploadStatsChart.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\Clip;
+use Filament\Forms\Components\DatePicker;
+use Filament\Schemas\Schema;
+use Filament\Widgets\ChartWidget;
+use Illuminate\Support\Facades\DB;
+
+class UploadStatsChart extends ChartWidget
+{
+    protected ?string $heading = 'Uploads per Submitter';
+
+    public ?array $filters = [];
+
+    public function mount(): void
+    {
+        $this->filters = [
+            'from' => now()->subMonth()->toDateString(),
+            'to' => now()->toDateString(),
+        ];
+
+        parent::mount();
+    }
+
+    public function filtersSchema(Schema $schema): Schema
+    {
+        return $schema
+            ->columns(2)
+            ->components([
+                DatePicker::make('from')->label('Von')->required(),
+                DatePicker::make('to')->label('Bis')->required(),
+            ]);
+    }
+
+    protected function getData(): array
+    {
+        $from = $this->filters['from'] ?? now()->subMonth()->toDateString();
+        $to = $this->filters['to'] ?? now()->toDateString();
+
+        $rows = Clip::query()
+            ->whereBetween('created_at', [$from, $to])
+            ->select('submitted_by', DB::raw('count(*) as count'))
+            ->groupBy('submitted_by')
+            ->orderByDesc('count')
+            ->get();
+
+        $labels = $rows->map(fn($row) => $row->submitted_by ?? 'Unknown')->all();
+        $data = $rows->map(fn($row) => (int) $row->count)->all();
+
+        $colorPalette = [
+            '#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6',
+            '#ec4899', '#14b8a6', '#f97316', '#84cc16', '#06b6d4',
+        ];
+
+        return [
+            'datasets' => [
+                [
+                    'label' => 'Uploads',
+                    'data' => $data,
+                    'backgroundColor' => array_slice($colorPalette, 0, count($data)),
+                ],
+            ],
+            'labels' => $labels,
+        ];
+    }
+
+    protected function getType(): string
+    {
+        return 'pie';
+    }
+}

--- a/resources/views/filament/pages/statistics.blade.php
+++ b/resources/views/filament/pages/statistics.blade.php
@@ -1,0 +1,26 @@
+<x-filament-panels::page>
+    <x-filament::tabs>
+        <x-filament::tabs.item wire:click="$set('tab', 'assignments')" :active="$tab === 'assignments'">
+            Assignments
+        </x-filament::tabs.item>
+        <x-filament::tabs.item wire:click="$set('tab', 'uploads')" :active="$tab === 'uploads'">
+            Uploads
+        </x-filament::tabs.item>
+        <x-filament::tabs.item wire:click="$set('tab', 'downloads')" :active="$tab === 'downloads'">
+            Downloads
+        </x-filament::tabs.item>
+    </x-filament::tabs>
+
+    <div class="mt-6 space-y-6">
+        @if ($tab === 'assignments')
+            @livewire(\App\Filament\Widgets\AssignmentStatusChart::class)
+        @elseif ($tab === 'uploads')
+            @livewire(\App\Filament\Widgets\UploadStatsChart::class)
+        @elseif ($tab === 'downloads')
+            <div class="grid gap-6">
+                @livewire(\App\Filament\Widgets\DownloadDelayChart::class)
+                @livewire(\App\Filament\Widgets\DownloadsPerHourChart::class)
+            </div>
+        @endif
+    </div>
+</x-filament-panels::page>

--- a/tests/Feature/Filament/Pages/StatisticsPageTest.php
+++ b/tests/Feature/Filament/Pages/StatisticsPageTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament\Pages;
+
+use App\Filament\Pages\Statistics;
+use Tests\DatabaseTestCase;
+
+final class StatisticsPageTest extends DatabaseTestCase
+{
+    public function testDefaultTabIsAssignments(): void
+    {
+        $page = app(Statistics::class);
+        $this->assertSame('assignments', $page->tab);
+    }
+}

--- a/tests/Feature/Filament/Widgets/AssignmentStatusChartTest.php
+++ b/tests/Feature/Filament/Widgets/AssignmentStatusChartTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament\Widgets;
+
+use App\Enum\StatusEnum;
+use App\Filament\Widgets\AssignmentStatusChart;
+use App\Models\Assignment;
+use App\Models\Channel;
+use App\Models\Batch;
+use Tests\DatabaseTestCase;
+
+final class AssignmentStatusChartTest extends DatabaseTestCase
+{
+    public function testComputesPercentagesPerChannel(): void
+    {
+        $channelA = Channel::factory()->create(['name' => 'A']);
+        $channelB = Channel::factory()->create(['name' => 'B']);
+        $batch = Batch::factory()->type('assign')->create();
+
+        Assignment::factory()->count(2)->forChannel($channelA)->withBatch($batch)->create([
+            'status' => StatusEnum::PICKEDUP->value,
+        ]);
+        Assignment::factory()->forChannel($channelA)->withBatch($batch)->create([
+            'status' => StatusEnum::NOTIFIED->value,
+        ]);
+        Assignment::factory()->forChannel($channelA)->withBatch($batch)->create([
+            'status' => StatusEnum::REJECTED->value,
+        ]);
+
+        Assignment::factory()->forChannel($channelB)->withBatch($batch)->create([
+            'status' => StatusEnum::PICKEDUP->value,
+        ]);
+        Assignment::factory()->forChannel($channelB)->withBatch($batch)->create([
+            'status' => StatusEnum::NOTIFIED->value,
+        ]);
+
+        $widget = app(AssignmentStatusChart::class);
+        $widget->filters = [
+            'from' => now()->subDay()->toDateString(),
+            'to' => now()->addDay()->toDateString(),
+        ];
+        $data = \invade($widget)->getData();
+
+        $this->assertSame(['A', 'B'], $data['labels']);
+        $this->assertEquals([
+            [
+                'label' => 'Picked up',
+                'data' => [50.0, 50.0],
+                'backgroundColor' => '#10b981',
+                'borderColor' => '#10b981',
+            ],
+            [
+                'label' => 'Notified',
+                'data' => [25.0, 50.0],
+                'backgroundColor' => '#3b82f6',
+                'borderColor' => '#3b82f6',
+            ],
+            [
+                'label' => 'Rejected',
+                'data' => [25.0, 0.0],
+                'backgroundColor' => '#ef4444',
+                'borderColor' => '#ef4444',
+            ],
+        ], $data['datasets']);
+    }
+}

--- a/tests/Feature/Filament/Widgets/DownloadDelayChartTest.php
+++ b/tests/Feature/Filament/Widgets/DownloadDelayChartTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament\Widgets;
+
+use App\Filament\Widgets\DownloadDelayChart;
+use App\Models\Assignment;
+use App\Models\Download;
+use App\Models\Batch;
+use Carbon\Carbon;
+use Tests\DatabaseTestCase;
+
+final class DownloadDelayChartTest extends DatabaseTestCase
+{
+    public function testCalculatesAverageAndMedianDelay(): void
+    {
+        $notified = Carbon::now();
+        $batch = Batch::factory()->type('assign')->create();
+        $a1 = Assignment::factory()->withBatch($batch)->create(['last_notified_at' => $notified]);
+        $a2 = Assignment::factory()->withBatch($batch)->create(['last_notified_at' => $notified]);
+
+        Download::factory()->forAssignment($a1)->create([
+            'downloaded_at' => $notified->copy()->addMinutes(10),
+        ]);
+        Download::factory()->forAssignment($a2)->create([
+            'downloaded_at' => $notified->copy()->addMinutes(20),
+        ]);
+
+        $widget = app(DownloadDelayChart::class);
+        $widget->filters = [
+            'from' => now()->subDay()->toDateString(),
+            'to' => now()->addDay()->toDateString(),
+        ];
+        $data = \invade($widget)->getData();
+
+        $this->assertSame(['Average', 'Median'], $data['labels']);
+        $this->assertEquals([15.0, 15.0], $data['datasets'][0]['data']);
+    }
+}

--- a/tests/Feature/Filament/Widgets/DownloadsPerHourChartTest.php
+++ b/tests/Feature/Filament/Widgets/DownloadsPerHourChartTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament\Widgets;
+
+use App\Filament\Widgets\DownloadsPerHourChart;
+use App\Models\Assignment;
+use App\Models\Download;
+use App\Models\Batch;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use Tests\DatabaseTestCase;
+
+final class DownloadsPerHourChartTest extends DatabaseTestCase
+{
+    public function testAggregatesDownloadsPerHour(): void
+    {
+        $pdo = DB::connection()->getPdo();
+        if (method_exists($pdo, 'sqliteCreateFunction')) {
+            $pdo->sqliteCreateFunction('HOUR', fn($value) => (int) Carbon::parse($value)->format('H'));
+        }
+
+        $assignment = Assignment::factory()->withBatch(Batch::factory()->type('assign')->create())->create();
+        $base = Carbon::now()->startOfDay();
+        Download::factory()->forAssignment($assignment)->at($base->copy()->setHour(14))->create();
+        Download::factory()->forAssignment($assignment)->at($base->copy()->setHour(16))->create();
+        Download::factory()->forAssignment($assignment)->at($base->copy()->setHour(16)->addMinutes(30))->create();
+
+        $widget = app(DownloadsPerHourChart::class);
+        $widget->filters = [
+            'from' => now()->subDay()->toDateString(),
+            'to' => now()->addDay()->toDateString(),
+        ];
+        $data = \invade($widget)->getData();
+
+        $this->assertSame('Downloads', $data['datasets'][0]['label']);
+        $this->assertSame(1, $data['datasets'][0]['data'][14]);
+        $this->assertSame(2, $data['datasets'][0]['data'][16]);
+        $this->assertSame('14', $data['labels'][14]);
+        $this->assertSame('16', $data['labels'][16]);
+    }
+}

--- a/tests/Feature/Filament/Widgets/UploadStatsChartTest.php
+++ b/tests/Feature/Filament/Widgets/UploadStatsChartTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament\Widgets;
+
+use App\Filament\Widgets\UploadStatsChart;
+use App\Models\Clip;
+use Tests\DatabaseTestCase;
+
+final class UploadStatsChartTest extends DatabaseTestCase
+{
+    public function testCountsUploadsPerSubmitter(): void
+    {
+        Clip::factory()->count(2)->submittedBy('alice@example.com')->create();
+        Clip::factory()->submittedBy('bob@example.com')->create();
+
+        $widget = app(UploadStatsChart::class);
+        $widget->filters = [
+            'from' => now()->subDay()->toDateString(),
+            'to' => now()->addDay()->toDateString(),
+        ];
+        $data = \invade($widget)->getData();
+
+        $this->assertSame(['alice@example.com', 'bob@example.com'], $data['labels']);
+        $this->assertSame([
+            [
+                'label' => 'Uploads',
+                'data' => [2, 1],
+                'backgroundColor' => ['#3b82f6', '#10b981'],
+            ],
+        ], $data['datasets']);
+    }
+}


### PR DESCRIPTION
## Summary
- refactor statistics page into chart widgets
- visualize assignments by channel, uploads per submitter, and download timings
- add statistics page with tabbed chart widgets
- cover statistics page and widgets with feature tests
- apply distinct color palettes to chart datasets for clarity
- document statistics charts in changelog

## Testing
- `composer test` *(fails: Script @php artisan test handling the test event returned with error code 1)*
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68b0a964e7a48329bed25a53d79afb19