### PR TITLE
Display raw assignment counts in statistics

### DIFF
--- a/app/Filament/Widgets/AssignmentStatusChart.php
+++ b/app/Filament/Widgets/AssignmentStatusChart.php
@@ -65,11 +65,7 @@ class AssignmentStatusChart extends ChartWidget
             $color = $colors[$status];
             $datasets[] = [
                 'label' => ucfirst(str_replace('_', ' ', $status)),
-                'data' => array_map(function ($channel) use ($stats, $status) {
-                    $total = $stats[$channel]['total'] ?: 1;
-                    $count = $stats[$channel][$status] ?? 0;
-                    return round($count / $total * 100, 2);
-                }, $labels),
+                'data' => array_map(fn ($channel) => $stats[$channel][$status] ?? 0, $labels),
                 'backgroundColor' => $color,
                 'borderColor' => $color,
             ];
@@ -78,6 +74,16 @@ class AssignmentStatusChart extends ChartWidget
         return [
             'datasets' => $datasets,
             'labels' => $labels,
+        ];
+    }
+
+    protected function getOptions(): array
+    {
+        return [
+            'scales' => [
+                'x' => ['stacked' => true],
+                'y' => ['stacked' => true],
+            ],
         ];
     }
 

--- a/resources/views/filament/pages/statistics.blade.php
+++ b/resources/views/filament/pages/statistics.blade.php
@@ -13,13 +13,21 @@
 
     <div class="mt-6 space-y-6">
         @if ($tab === 'assignments')
-            @livewire(\App\Filament\Widgets\AssignmentStatusChart::class)
+            @foreach ($this->getWidgetsSchemaComponents([\App\Filament\Widgets\AssignmentStatusChart::class]) as $widget)
+                {{ $widget }}
+            @endforeach
         @elseif ($tab === 'uploads')
-            @livewire(\App\Filament\Widgets\UploadStatsChart::class)
+            @foreach ($this->getWidgetsSchemaComponents([\App\Filament\Widgets\UploadStatsChart::class]) as $widget)
+                {{ $widget }}
+            @endforeach
         @elseif ($tab === 'downloads')
             <div class="grid gap-6">
-                @livewire(\App\Filament\Widgets\DownloadDelayChart::class)
-                @livewire(\App\Filament\Widgets\DownloadsPerHourChart::class)
+                @foreach ($this->getWidgetsSchemaComponents([
+                    \App\Filament\Widgets\DownloadDelayChart::class,
+                    \App\Filament\Widgets\DownloadsPerHourChart::class,
+                ]) as $widget)
+                    {{ $widget }}
+                @endforeach
             </div>
         @endif
     </div>

--- a/tests/Feature/Filament/Widgets/AssignmentStatusChartTest.php
+++ b/tests/Feature/Filament/Widgets/AssignmentStatusChartTest.php
@@ -13,7 +13,7 @@ use Tests\DatabaseTestCase;
 
 final class AssignmentStatusChartTest extends DatabaseTestCase
 {
-    public function testComputesPercentagesPerChannel(): void
+    public function testComputesCountsPerChannel(): void
     {
         $channelA = Channel::factory()->create(['name' => 'A']);
         $channelB = Channel::factory()->create(['name' => 'B']);
@@ -47,19 +47,19 @@ final class AssignmentStatusChartTest extends DatabaseTestCase
         $this->assertEquals([
             [
                 'label' => 'Picked up',
-                'data' => [50.0, 50.0],
+                'data' => [2, 1],
                 'backgroundColor' => '#10b981',
                 'borderColor' => '#10b981',
             ],
             [
                 'label' => 'Notified',
-                'data' => [25.0, 50.0],
+                'data' => [1, 1],
                 'backgroundColor' => '#3b82f6',
                 'borderColor' => '#3b82f6',
             ],
             [
                 'label' => 'Rejected',
-                'data' => [25.0, 0.0],
+                'data' => [1, 0],
                 'backgroundColor' => '#ef4444',
                 'borderColor' => '#ef4444',
             ],


### PR DESCRIPTION
## Summary
- render statistics widgets through Filament to expose filters
- show assignment counts per channel instead of percentages and stack bars
- update widget test for count-based data

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68b0c202da3883299a0403c785b524b2