### PR TITLE
Add tests for mail logging and reply scanner components

### DIFF
--- a/tests/Integration/Console/ScanMailRepliesCommandTest.php
+++ b/tests/Integration/Console/ScanMailRepliesCommandTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Console;
+
+use App\Facades\Cfg;
+use App\Services\Mail\Scanner\MailReplyScanner;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
+use Mockery;
+use Tests\DatabaseTestCase;
+
+class ScanMailRepliesCommandTest extends DatabaseTestCase
+{
+    protected function tearDown(): void
+    {
+        Cache::flush();
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function testItInvokesScannerWhenFaqEmailIsConfigured(): void
+    {
+        Cfg::set('faq_email', 'support@example.com', 'email');
+
+        $scanner = Mockery::mock(MailReplyScanner::class);
+        $scanner->shouldReceive('scan')->once();
+
+        $this->app->instance(MailReplyScanner::class, $scanner);
+
+        $this->artisan('mail:scan-replies')
+            ->assertExitCode(Command::SUCCESS);
+    }
+
+    public function testItSkipsScannerWhenFaqEmailDisabled(): void
+    {
+        Cfg::set('faq_email', 0, 'email', 'bool');
+
+        $scanner = Mockery::mock(MailReplyScanner::class);
+        $scanner->shouldReceive('scan')->never();
+
+        $this->app->instance(MailReplyScanner::class, $scanner);
+
+        $this->artisan('mail:scan-replies')
+            ->assertExitCode(Command::SUCCESS);
+    }
+}

--- a/tests/Integration/Services/Mail/MailReplyScannerBindingTest.php
+++ b/tests/Integration/Services/Mail/MailReplyScannerBindingTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Services\Mail;
+
+use App\Services\Mail\Scanner\Handlers\BounceHandler;
+use App\Services\Mail\Scanner\Handlers\ReplyHandler;
+use App\Services\Mail\Scanner\MailReplyScanner;
+use ReflectionProperty;
+use Tests\TestCase;
+
+class MailReplyScannerBindingTest extends TestCase
+{
+    public function testContainerResolvesSingletonWithExpectedHandlers(): void
+    {
+        $first = $this->app->make(MailReplyScanner::class);
+        $second = $this->app->make(MailReplyScanner::class);
+
+        $this->assertSame($first, $second, 'MailReplyScanner should be a singleton');
+
+        $reflection = new ReflectionProperty(MailReplyScanner::class, 'handlers');
+        $reflection->setAccessible(true);
+
+        $handlers = iterator_to_array($reflection->getValue($first));
+
+        $this->assertCount(2, $handlers);
+        $this->assertInstanceOf(BounceHandler::class, $handlers[0]);
+        $this->assertInstanceOf(ReplyHandler::class, $handlers[1]);
+    }
+}

--- a/tests/Unit/Listeners/LogSentMailTest.php
+++ b/tests/Unit/Listeners/LogSentMailTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Listeners;
+
+use App\Enum\MailStatus;
+use App\Listeners\LogSentMail;
+use App\Models\MailLog;
+use Illuminate\Mail\Events\MessageSent;
+use Illuminate\Mail\SentMessage as LaravelSentMessage;
+use Illuminate\Support\Facades\Log;
+use Mockery;
+use Symfony\Component\Mime\Header\Headers;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\SentMessage as SymfonySentMessage;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+use Tests\DatabaseTestCase;
+
+class LogSentMailTest extends DatabaseTestCase
+{
+    private function createEventFromEmail(Email $email, array $data = []): MessageSent
+    {
+        $from = $email->getFrom()[0] ?? new Address('no-reply@example.com');
+
+        $envelope = new Envelope($from, $email->getTo());
+
+        $sent = new SymfonySentMessage($email, $envelope);
+
+        return new MessageSent(new LaravelSentMessage($sent), $data);
+    }
+
+    public function testItPersistsMailLogWithHeadersAndContent(): void
+    {
+        $listener = new LogSentMail();
+
+        $email = (new Email())
+            ->from('noreply@example.com')
+            ->to('user@example.com')
+            ->subject('Welcome to Dashclip')
+            ->html('<p>Hello there!</p>');
+
+        $email->getHeaders()->addIdHeader('Message-ID', 'message-123@example.com');
+        $email->getHeaders()->addTextHeader('X-App-Message-ID', 'internal-456');
+
+        $event = $this->createEventFromEmail($email);
+
+        $listener->handle($event);
+
+        $log = MailLog::firstOrFail();
+
+        $this->assertSame('<message-123@example.com>', $log->message_id);
+        $this->assertSame('internal-456', $log->internal_id);
+        $this->assertSame('user@example.com', $log->to);
+        $this->assertSame('Welcome to Dashclip', $log->subject);
+        $this->assertSame(MailStatus::Sent, $log->status);
+        $this->assertSame('<p>Hello there!</p>', $log->meta['content']);
+        $this->assertContains('Message-ID: <message-123@example.com>', $log->meta['headers']);
+    }
+
+    public function testItFallsBackToEventHeadersWhenMessageLacksIds(): void
+    {
+        $listener = new LogSentMail();
+
+        $email = (new Email())
+            ->from('noreply@example.com')
+            ->to('another@example.com')
+            ->subject('Fallback IDs')
+            ->html('<p>Body</p>');
+
+        $event = $this->createEventFromEmail($email, [
+            'headers' => [
+                'Message-ID' => 'event-message-id',
+                'X-App-Message-ID' => 'event-internal-id',
+            ],
+        ]);
+
+        $listener->handle($event);
+
+        $log = MailLog::where('to', 'another@example.com')->firstOrFail();
+
+        $this->assertSame('event-message-id', $log->message_id);
+        $this->assertSame('event-internal-id', $log->internal_id);
+    }
+
+    public function testItSkipsLoggingWhenRecipientMissing(): void
+    {
+        $listener = new LogSentMail();
+
+        $headers = new Headers();
+
+        $address = new class {
+            public function getAddress(): ?string
+            {
+                return null;
+            }
+        };
+
+        $message = Mockery::mock(Email::class);
+        $message->shouldReceive('getHeaders')->andReturn($headers);
+        $message->shouldReceive('getTo')->andReturn([$address]);
+        $message->shouldReceive('getSubject')->andReturn('Subjectless');
+        $message->shouldReceive('getHtmlBody')->andReturn('<p>Empty</p>');
+
+        $symfonySent = Mockery::mock(SymfonySentMessage::class);
+        $symfonySent->shouldReceive('getOriginalMessage')->andReturn($message);
+
+        $event = new MessageSent(new LaravelSentMessage($symfonySent), ['headers' => []]);
+
+        Log::shouldReceive('warning')
+            ->once()
+            ->with('MessageSent without recipient', Mockery::type('array'));
+
+        $listener->handle($event);
+
+        $this->assertDatabaseCount('mail_logs', 0);
+    }
+}

--- a/tests/Unit/Services/Mail/Scanner/Handlers/BounceHandlerTest.php
+++ b/tests/Unit/Services/Mail/Scanner/Handlers/BounceHandlerTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Mail\Scanner\Handlers;
+
+use App\Enum\MailStatus;
+use App\Models\MailLog;
+use App\Services\Mail\Scanner\Handlers\BounceHandler;
+use Illuminate\Support\Facades\Log;
+use Mockery;
+use Tests\DatabaseTestCase;
+use Webklex\PHPIMAP\Message;
+
+class BounceHandlerTest extends DatabaseTestCase
+{
+    public function testMatchesReturnsTrueForKnownBounceSubjects(): void
+    {
+        $subject = Mockery::mock();
+        $subject->shouldReceive('toString')->andReturn('Mail Delivery Failed: Undeliverable');
+
+        $message = Mockery::mock(Message::class);
+        $message->shouldReceive('getSubject')->andReturn($subject);
+
+        $handler = new BounceHandler();
+
+        $this->assertTrue($handler->matches($message));
+    }
+
+    public function testMatchesReturnsFalseForOtherSubjects(): void
+    {
+        $subject = Mockery::mock();
+        $subject->shouldReceive('toString')->andReturn('Regular update');
+
+        $message = Mockery::mock(Message::class);
+        $message->shouldReceive('getSubject')->andReturn($subject);
+
+        $handler = new BounceHandler();
+
+        $this->assertFalse($handler->matches($message));
+    }
+
+    public function testHandleUpdatesMailLogWhenOriginalMessageFound(): void
+    {
+        $log = MailLog::create([
+            'message_id' => 'original-message-id@example.com',
+            'to' => 'user@example.com',
+            'subject' => 'Initial Mail',
+            'status' => MailStatus::Sent,
+        ]);
+
+        $body = "Delivery failed\nMessage-ID: <original-message-id@example.com>\nAdditional info";
+
+        $message = Mockery::mock(Message::class);
+        $message->shouldReceive('getTextBody')->andReturn($body);
+
+        Log::shouldReceive('info')
+            ->once()
+            ->with('Bounce for original-message-id@example.com');
+
+        $handler = new BounceHandler();
+        $handler->handle($message);
+
+        $log->refresh();
+
+        $this->assertSame(MailStatus::Bounced, $log->status);
+        $this->assertNotNull($log->bounced_at);
+        $this->assertArrayHasKey('bounce_excerpt', $log->meta);
+        $this->assertSame(substr($body, 0, 400), $log->meta['bounce_excerpt']);
+    }
+
+    public function testHandleSkipsWhenMailLogCannotBeResolved(): void
+    {
+        $message = Mockery::mock(Message::class);
+        $message->shouldReceive('getTextBody')->andReturn('No matching id here');
+
+        Log::shouldReceive('info')->never();
+
+        $handler = new BounceHandler();
+        $handler->handle($message);
+
+        $this->assertDatabaseCount('mail_logs', 0);
+    }
+}

--- a/tests/Unit/Services/Mail/Scanner/Handlers/ReplyHandlerTest.php
+++ b/tests/Unit/Services/Mail/Scanner/Handlers/ReplyHandlerTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Mail\Scanner\Handlers;
+
+use App\Enum\MailStatus;
+use App\Mail\NoReplyFAQMail;
+use App\Models\MailLog;
+use App\Services\Mail\Scanner\Handlers\ReplyHandler;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+use Mockery;
+use Tests\DatabaseTestCase;
+use Webklex\PHPIMAP\Message;
+
+class ReplyHandlerTest extends DatabaseTestCase
+{
+    public function testMatchesReturnsTrueWhenInReplyToHeaderPresent(): void
+    {
+        $inReplyTo = Mockery::mock();
+
+        $message = Mockery::mock(Message::class);
+        $message->shouldReceive('getInReplyTo')->andReturn($inReplyTo);
+
+        $handler = new ReplyHandler();
+
+        $this->assertTrue($handler->matches($message));
+    }
+
+    public function testMatchesReturnsFalseWhenNoReplyHeaderPresent(): void
+    {
+        $message = Mockery::mock(Message::class);
+        $message->shouldReceive('getInReplyTo')->andReturn(null);
+
+        $handler = new ReplyHandler();
+
+        $this->assertFalse($handler->matches($message));
+    }
+
+    public function testHandleQueuesAutoResponderAndUpdatesMailLog(): void
+    {
+        Mail::fake();
+
+        $log = MailLog::create([
+            'message_id' => '<thread-123@example.com>',
+            'to' => 'user@example.com',
+            'subject' => 'Support Request',
+            'status' => MailStatus::Sent,
+        ]);
+
+        $from = new class('customer@example.com') {
+            public function __construct(public string $mail)
+            {
+            }
+        };
+
+        $inReplyTo = Mockery::mock();
+        $inReplyTo->shouldReceive('toString')->andReturn('thread-123@example.com');
+
+        $message = Mockery::mock(Message::class);
+        $message->shouldReceive('getInReplyTo')->andReturn($inReplyTo);
+        $message->shouldReceive('getFrom')->andReturn([$from]);
+
+        Log::shouldReceive('info')
+            ->once()
+            ->with('Auto-reply sent to customer@example.com');
+
+        $handler = new ReplyHandler();
+        $handler->handle($message);
+
+        $log->refresh();
+
+        Mail::assertQueued(NoReplyFAQMail::class, fn ($mail) => true);
+
+        $this->assertSame(MailStatus::Replied, $log->status);
+        $this->assertNotNull($log->replied_at);
+    }
+
+    public function testHandleDoesNothingWhenNoMatchingLogExists(): void
+    {
+        Mail::fake();
+
+        $from = new class('customer@example.com') {
+            public function __construct(public string $mail)
+            {
+            }
+        };
+
+        $inReplyTo = Mockery::mock();
+        $inReplyTo->shouldReceive('toString')->andReturn('missing-thread@example.com');
+
+        $message = Mockery::mock(Message::class);
+        $message->shouldReceive('getInReplyTo')->andReturn($inReplyTo);
+        $message->shouldReceive('getFrom')->andReturn([$from]);
+
+        Log::shouldReceive('info')->never();
+
+        $handler = new ReplyHandler();
+        $handler->handle($message);
+
+        Mail::assertNothingQueued();
+        $this->assertDatabaseCount('mail_logs', 0);
+    }
+
+    public function testHandleSkipsWhenAlreadyReplied(): void
+    {
+        Mail::fake();
+
+        MailLog::create([
+            'message_id' => '<answered@example.com>',
+            'to' => 'user@example.com',
+            'subject' => 'Support Request',
+            'status' => MailStatus::Replied,
+        ]);
+
+        $from = new class('customer@example.com') {
+            public function __construct(public string $mail)
+            {
+            }
+        };
+
+        $inReplyTo = Mockery::mock();
+        $inReplyTo->shouldReceive('toString')->andReturn('answered@example.com');
+
+        $message = Mockery::mock(Message::class);
+        $message->shouldReceive('getInReplyTo')->andReturn($inReplyTo);
+        $message->shouldReceive('getFrom')->andReturn([$from]);
+
+        Log::shouldReceive('info')->never();
+
+        $handler = new ReplyHandler();
+        $handler->handle($message);
+
+        Mail::assertNothingQueued();
+        $this->assertSame(1, MailLog::count());
+    }
+}

--- a/tests/Unit/Services/Mail/Scanner/MailReplyScannerTest.php
+++ b/tests/Unit/Services/Mail/Scanner/MailReplyScannerTest.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Mail\Scanner;
+
+use App\Services\Mail\Scanner\Contracts\MessageStrategyInterface;
+use App\Services\Mail\Scanner\Contracts\MoveToFolderInterface;
+use App\Services\Mail\Scanner\MailReplyScanner;
+use Illuminate\Support\Facades\Log;
+use Mockery;
+use Tests\TestCase;
+use Webklex\IMAP\Facades\Client;
+use Webklex\PHPIMAP\Client as ClientAlias;
+use Webklex\PHPIMAP\Message;
+
+class MailReplyScannerTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function testItSkipsAutoSubmittedMessagesAndMarksThemSeen(): void
+    {
+        $handler = new FakeHandler();
+
+        $scanner = new MailReplyScanner([$handler]);
+
+        $client = Mockery::mock(ClientAlias::class);
+        Client::shouldReceive('account')->once()->with(null)->andReturn($client);
+        $client->shouldReceive('connect')->once();
+
+        $inbox = Mockery::mock(\Webklex\PHPIMAP\Folder::class);
+        $query = Mockery::mock(\Webklex\PHPIMAP\Query\WhereQuery::class);
+        $client->shouldReceive('getFolder')->with('INBOX')->andReturn($inbox);
+        $inbox->shouldReceive('messages')->andReturn($query);
+        $query->shouldReceive('unseen')->andReturn($query);
+
+        $message = $this->createMessageMock(autoSubmitted: true);
+        $message->shouldReceive('setFlag')->with('Seen')->once();
+        $query->shouldReceive('get')->andReturn(new \Webklex\PHPIMAP\Support\MessageCollection([$message]));
+
+        Log::shouldReceive('info')
+            ->once()
+            ->with(Mockery::on(fn ($message) => str_contains($message, 'was ignored')));
+        Log::shouldReceive('error')->never();
+
+        $scanner->scan();
+
+        $this->assertSame(0, $handler->matchesCalled);
+        $this->assertSame(0, $handler->handledCalled);
+    }
+
+    public function testItDispatchesMatchingHandlersMovesMessageAndCreatesFolders(): void
+    {
+        config()->set('app.debug', false);
+
+        $handler = new FakeHandler();
+
+        $scanner = new MailReplyScanner([$handler]);
+
+        $client = Mockery::mock(ClientAlias::class);
+        Client::shouldReceive('account')->once()->with(null)->andReturn($client);
+        $client->shouldReceive('connect')->once();
+
+        $inbox = Mockery::mock(\Webklex\PHPIMAP\Folder::class);
+        $query = Mockery::mock(\Webklex\PHPIMAP\Query\WhereQuery::class);
+        $client->shouldReceive('getFolder')->with('INBOX')->andReturn($inbox);
+        $inbox->shouldReceive('messages')->andReturn($query);
+        $query->shouldReceive('unseen')->andReturn($query);
+
+        $message = $this->createMessageMock();
+        $message->shouldReceive('setFlag')->with('Seen')->once();
+        $query->shouldReceive('get')->andReturn(new \Webklex\PHPIMAP\Support\MessageCollection([$message]));
+
+        $client->shouldReceive('getFolder')->with('Processed/Test')->andReturn(null);
+        $client->shouldReceive('createFolder')->once()->with('Processed/Test');
+
+        Log::shouldReceive('info')->once();
+        Log::shouldReceive('error')->never();
+
+        $message->shouldReceive('move')->once()->with('Processed/Test');
+
+        $scanner->scan();
+
+        $this->assertSame(1, $handler->matchesCalled);
+        $this->assertSame(1, $handler->handledCalled);
+    }
+
+    public function testItSkipsMovingMessagesWhenInDebugMode(): void
+    {
+        config()->set('app.debug', true);
+
+        $handler = new FakeHandler();
+
+        $scanner = new MailReplyScanner([$handler]);
+
+        $client = Mockery::mock(ClientAlias::class);
+        Client::shouldReceive('account')->once()->with(null)->andReturn($client);
+        $client->shouldReceive('connect')->once();
+
+        $inbox = Mockery::mock(\Webklex\PHPIMAP\Folder::class);
+        $query = Mockery::mock(\Webklex\PHPIMAP\Query\WhereQuery::class);
+        $client->shouldReceive('getFolder')->with('INBOX')->andReturn($inbox);
+        $inbox->shouldReceive('messages')->andReturn($query);
+        $query->shouldReceive('unseen')->andReturn($query);
+
+        $message = $this->createMessageMock();
+        $message->shouldReceive('setFlag')->with('Seen')->once();
+        $query->shouldReceive('get')->andReturn(new \Webklex\PHPIMAP\Support\MessageCollection([$message]));
+
+        $client->shouldReceive('getFolder')->with('Processed/Test')->never();
+        $client->shouldReceive('createFolder')->never();
+
+        $message->shouldReceive('move')->never();
+        Log::shouldReceive('error')->never();
+
+        $scanner->scan();
+
+        $this->assertSame(1, $handler->matchesCalled);
+        $this->assertSame(1, $handler->handledCalled);
+    }
+
+    public function testItFlagsMessagesWhenHandlerThrows(): void
+    {
+        config()->set('app.debug', false);
+
+        $handler = new FakeHandler(shouldMatch: true, throwable: new \RuntimeException('failed'));
+
+        $scanner = new MailReplyScanner([$handler]);
+
+        $client = Mockery::mock(ClientAlias::class);
+        Client::shouldReceive('account')->once()->with(null)->andReturn($client);
+        $client->shouldReceive('connect')->once();
+
+        $inbox = Mockery::mock(\Webklex\PHPIMAP\Folder::class);
+        $query = Mockery::mock(\Webklex\PHPIMAP\Query\WhereQuery::class);
+        $client->shouldReceive('getFolder')->with('INBOX')->andReturn($inbox);
+        $inbox->shouldReceive('messages')->andReturn($query);
+        $query->shouldReceive('unseen')->andReturn($query);
+
+        $message = $this->createMessageMock();
+        $query->shouldReceive('get')->andReturn(new \Webklex\PHPIMAP\Support\MessageCollection([$message]));
+
+        $client->shouldReceive('getFolder')->with('Processed/Test')->never();
+        $client->shouldReceive('createFolder')->never();
+
+        Log::shouldReceive('error')
+            ->once()
+            ->with('IMAP processing failed', Mockery::type('array'));
+
+        $message->shouldReceive('setFlag')->with('Flagged')->once();
+        $message->shouldReceive('setFlag')->with('Seen')->never();
+
+        $scanner->scan();
+
+        $this->assertSame(1, $handler->matchesCalled);
+        $this->assertSame(1, $handler->handledCalled);
+    }
+
+    private function createMessageMock(bool $autoSubmitted = false)
+    {
+        $message = Mockery::mock(Message::class);
+
+        $headers = Mockery::mock(\Webklex\PHPIMAP\Header::class);
+        $headers->shouldReceive('has')->with('Auto-Submitted')->andReturn($autoSubmitted);
+        $message->shouldReceive('getHeader')->andReturn($headers);
+
+        $messageId = Mockery::mock();
+        $messageId->shouldReceive('toString')->andReturn('msg-1');
+        $message->shouldReceive('getMessageId')->andReturn($messageId);
+
+        return $message;
+    }
+}
+
+class FakeHandler implements MessageStrategyInterface, MoveToFolderInterface
+{
+    public int $matchesCalled = 0;
+    public int $handledCalled = 0;
+
+    public function __construct(
+        public bool $shouldMatch = true,
+        public ?\Throwable $throwable = null
+    ) {
+    }
+
+    public function matches(Message $message): bool
+    {
+        $this->matchesCalled++;
+
+        return $this->shouldMatch;
+    }
+
+    public function handle(Message $message): void
+    {
+        if ($this->throwable) {
+            $this->handledCalled++;
+            throw $this->throwable;
+        }
+
+        $this->handledCalled++;
+    }
+
+    public function getMoveToFolderPath(): string
+    {
+        return 'Processed/Test';
+    }
+}


### PR DESCRIPTION
## Summary
- add unit coverage for the LogSentMail listener including fallback logic and missing recipient handling
- cover MailReplyScanner handlers and dispatcher logic with dedicated unit tests
- add integration checks for the scan command gate and the container binding of the reply scanner

## Testing
- ./vendor/bin/phpunit --no-coverage tests/Unit/Listeners/LogSentMailTest.php
- ./vendor/bin/phpunit --no-coverage tests/Unit/Services/Mail/Scanner/Handlers/BounceHandlerTest.php
- ./vendor/bin/phpunit --no-coverage tests/Unit/Services/Mail/Scanner/Handlers/ReplyHandlerTest.php
- ./vendor/bin/phpunit --no-coverage tests/Unit/Services/Mail/Scanner/MailReplyScannerTest.php
- ./vendor/bin/phpunit --no-coverage tests/Integration/Console/ScanMailRepliesCommandTest.php
- ./vendor/bin/phpunit --no-coverage tests/Integration/Services/Mail/MailReplyScannerBindingTest.php


------
https://chatgpt.com/codex/tasks/task_e_68e816bcba8c8329bdbc713dcc3898f6