### PR TITLE
Add integration tests for outbound mailables

### DIFF
--- a/tests/Integration/Mail/AbstractLoggedMailTest.php
+++ b/tests/Integration/Mail/AbstractLoggedMailTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Mail;
+
+use App\Mail\AbstractLoggedMail;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Headers;
+use Tests\TestCase;
+
+class AbstractLoggedMailTest extends TestCase
+{
+    public function testHeadersIncludeGeneratedMessageIdAndDefaultAutoSubmitted(): void
+    {
+        config(['mail.from.address' => 'mailer@example.com']);
+
+        $mail = new class extends AbstractLoggedMail {
+            protected string $subjectLine = 'Integration Subject';
+
+            protected function viewName(): string
+            {
+                return 'emails.stub';
+            }
+
+            protected function viewData(): array
+            {
+                return ['foo' => 'bar'];
+            }
+        };
+
+        $headers = $mail->headers();
+
+        $this->assertInstanceOf(Headers::class, $headers);
+        $this->assertNotEmpty($headers->messageId);
+        $this->assertStringContainsString('@example.com', $headers->messageId);
+        $this->assertStringNotContainsString('<', $headers->messageId);
+        $this->assertSame('auto-generated', $headers->text['Auto-Submitted']);
+        $this->assertArrayHasKey('X-System-Meta', $headers->text);
+        $this->assertArrayNotHasKey('X-Auto-Response-Suppress', $headers->text);
+    }
+
+    public function testContentIncludesSubjectAndViewData(): void
+    {
+        config(['mail.from.address' => 'mailer@example.com']);
+
+        $mail = new class extends AbstractLoggedMail {
+            protected string $subjectLine = 'Integration Subject';
+
+            protected function viewName(): string
+            {
+                return 'emails.stub';
+            }
+
+            protected function viewData(): array
+            {
+                return ['foo' => 'value'];
+            }
+        };
+
+        $content = $mail->content();
+
+        $this->assertInstanceOf(Content::class, $content);
+        $this->assertSame('emails.stub', $content->view);
+        $this->assertSame('Integration Subject', $content->with['subject']);
+        $this->assertSame('value', $content->with['foo']);
+    }
+
+    public function testAutoResponderHeadersOverrideDefaultsAndUseFallbackDomain(): void
+    {
+        config([
+            'mail.from.address' => null,
+            'app.url' => 'https://mailer.test',
+        ]);
+
+        $mail = new class extends AbstractLoggedMail {
+            protected string $subjectLine = 'Auto Subject';
+            protected bool $isAutoResponder = true;
+
+            protected function viewName(): string
+            {
+                return 'emails.stub';
+            }
+        };
+
+        $headers = $mail->headers();
+
+        $this->assertSame('auto-replied', $headers->text['Auto-Submitted']);
+        $this->assertSame('All', $headers->text['X-Auto-Response-Suppress']);
+        $this->assertStringContainsString('@mailer.test', $headers->messageId);
+        $this->assertStringNotContainsString('<', $headers->messageId);
+    }
+}

--- a/tests/Integration/Mail/NewOfferMailTest.php
+++ b/tests/Integration/Mail/NewOfferMailTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Mail;
+
+use App\Facades\Cfg;
+use App\Mail\NewOfferMail;
+use App\Models\Batch;
+use App\Models\Channel;
+use App\Models\Config;
+use App\Services\Contracts\ConfigServiceInterface;
+use BadMethodCallException;
+use Carbon\Carbon;
+use Tests\TestCase;
+
+class NewOfferMailTest extends TestCase
+{
+    public function testEnvelopeUsesConfigForBccAndSubject(): void
+    {
+        $this->fakeConfig([
+            'email' => [
+                'email_admin_mail' => 'admin@example.com',
+                'email_get_bcc_notification' => true,
+            ],
+        ]);
+
+        $batch = new Batch();
+        $batch->setAttribute('id', 7);
+
+        $channel = new Channel(['name' => 'Creator Channel']);
+
+        $mail = new NewOfferMail(
+            $batch,
+            $channel,
+            'https://example.com/offers/7',
+            Carbon::parse('2024-10-05 12:00:00'),
+            'https://example.com/offers/7/unused',
+        );
+
+        $envelope = $mail->envelope();
+
+        $this->assertSame('Neue Videos verfügbar – Batch #7', $envelope->subject);
+        $this->assertCount(1, $envelope->bcc);
+        $this->assertSame('admin@example.com', $envelope->bcc[0]->address ?? null);
+    }
+
+    public function testContentProvidesTemplateDataAndSubject(): void
+    {
+        $this->fakeConfig([
+            'email' => [
+                'email_admin_mail' => 'admin@example.com',
+                'email_get_bcc_notification' => false,
+            ],
+        ]);
+
+        $batch = new Batch();
+        $batch->setAttribute('id', 9);
+
+        $channel = new Channel(['name' => 'Main Channel']);
+        $expiresAt = Carbon::parse('2024-10-07 10:00:00');
+
+        $mail = new NewOfferMail(
+            $batch,
+            $channel,
+            'https://example.com/offers/9',
+            $expiresAt,
+            'https://example.com/offers/9/unused',
+        );
+
+        $content = $mail->content();
+
+        $this->assertSame('emails.new-offer', $content->view);
+        $this->assertSame('Neue Videos verfügbar – Batch #9', $content->with['subject']);
+        $this->assertSame($batch, $content->with['batch']);
+        $this->assertSame($channel, $content->with['channel']);
+        $this->assertSame('https://example.com/offers/9', $content->with['offerUrl']);
+        $this->assertTrue($expiresAt->equalTo($content->with['expiresAt']));
+        $this->assertSame('https://example.com/offers/9/unused', $content->with['unusedUrl']);
+    }
+
+    private function fakeConfig(array $values): void
+    {
+        $service = new class($values) implements ConfigServiceInterface {
+            public function __construct(private array $values)
+            {
+            }
+
+            public function get(
+                string $key,
+                ?string $category = null,
+                mixed $default = null,
+                bool $withoutCache = false
+            ): mixed {
+                if ($category !== null) {
+                    return $this->values[$category][$key] ?? $default;
+                }
+
+                return $this->values[$key] ?? $default;
+            }
+
+            public function set(
+                string $key,
+                mixed $value,
+                ?string $category = null,
+                string $castType = 'string',
+                bool $isVisible = true
+            ): Config {
+                throw new BadMethodCallException('ConfigService stub does not support set().');
+            }
+
+            public function has(string $key, ?string $category = null): bool
+            {
+                if ($category !== null) {
+                    return array_key_exists($key, $this->values[$category] ?? []);
+                }
+
+                return array_key_exists($key, $this->values);
+            }
+        };
+
+        Cfg::swap($service);
+    }
+}

--- a/tests/Integration/Mail/NoReplyFAQMailTest.php
+++ b/tests/Integration/Mail/NoReplyFAQMailTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Mail;
+
+use App\Mail\NoReplyFAQMail;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Headers;
+use Tests\TestCase;
+
+class NoReplyFAQMailTest extends TestCase
+{
+    public function testEnvelopeProvidesStaticSubject(): void
+    {
+        $mail = new NoReplyFAQMail();
+
+        $envelope = $mail->envelope();
+
+        $this->assertSame('Automatische Antwort – bitte nicht direkt antworten', $envelope->subject);
+    }
+
+    public function testHeadersIndicateAutoResponder(): void
+    {
+        $mail = new NoReplyFAQMail();
+
+        $headers = $mail->headers();
+
+        $this->assertInstanceOf(Headers::class, $headers);
+        $this->assertSame('auto-replied', $headers->text['Auto-Submitted']);
+        $this->assertSame('All', $headers->text['X-Auto-Response-Suppress']);
+    }
+
+    public function testContentUsesFaqTemplate(): void
+    {
+        $mail = new NoReplyFAQMail();
+
+        $content = $mail->content();
+
+        $this->assertInstanceOf(Content::class, $content);
+        $this->assertSame('emails.no_reply_faq', $content->view);
+        $this->assertSame(
+            'Automatische Antwort – bitte nicht direkt antworten',
+            $content->with['subject']
+        );
+    }
+}

--- a/tests/Integration/Mail/ReminderMailTest.php
+++ b/tests/Integration/Mail/ReminderMailTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Mail;
+
+use App\Facades\Cfg;
+use App\Mail\ReminderMail;
+use App\Models\Channel;
+use App\Models\Config;
+use App\Services\Contracts\ConfigServiceInterface;
+use BadMethodCallException;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+use Tests\TestCase;
+
+class ReminderMailTest extends TestCase
+{
+    public function testEnvelopeUsesConfigForBccAndSubject(): void
+    {
+        $this->fakeConfig([
+            'email' => [
+                'email_admin_mail' => 'admin@example.com',
+                'email_get_bcc_notification' => true,
+            ],
+        ]);
+
+        $channel = new Channel(['name' => 'Reminder Channel']);
+
+        $mail = new ReminderMail(
+            $channel,
+            'https://example.com/reminders/1',
+            Carbon::parse('2024-10-06 08:30:00'),
+            Collection::make(['assignment-a']),
+        );
+
+        $envelope = $mail->envelope();
+
+        $this->assertSame('Erinnerung: Angebote laufen bald ab', $envelope->subject);
+        $this->assertCount(1, $envelope->bcc);
+        $this->assertSame('admin@example.com', $envelope->bcc[0]->address ?? null);
+    }
+
+    public function testContentProvidesTemplateDataAndSubject(): void
+    {
+        $this->fakeConfig([
+            'email' => [
+                'email_admin_mail' => 'admin@example.com',
+                'email_get_bcc_notification' => false,
+            ],
+        ]);
+
+        $channel = new Channel(['name' => 'Reminder Channel']);
+        $expiresAt = Carbon::parse('2024-10-08 09:00:00');
+        $assignments = Collection::make(['assignment-a', 'assignment-b']);
+
+        $mail = new ReminderMail(
+            $channel,
+            'https://example.com/reminders/2',
+            $expiresAt,
+            $assignments,
+        );
+
+        $content = $mail->content();
+
+        $this->assertSame('emails.reminder', $content->view);
+        $this->assertSame('Erinnerung: Angebote laufen bald ab', $content->with['subject']);
+        $this->assertSame($channel, $content->with['channel']);
+        $this->assertSame('https://example.com/reminders/2', $content->with['offerUrl']);
+        $this->assertTrue($expiresAt->equalTo($content->with['expiresAt']));
+        $this->assertSame($assignments, $content->with['assignments']);
+    }
+
+    private function fakeConfig(array $values): void
+    {
+        $service = new class($values) implements ConfigServiceInterface {
+            public function __construct(private array $values)
+            {
+            }
+
+            public function get(
+                string $key,
+                ?string $category = null,
+                mixed $default = null,
+                bool $withoutCache = false
+            ): mixed {
+                if ($category !== null) {
+                    return $this->values[$category][$key] ?? $default;
+                }
+
+                return $this->values[$key] ?? $default;
+            }
+
+            public function set(
+                string $key,
+                mixed $value,
+                ?string $category = null,
+                string $castType = 'string',
+                bool $isVisible = true
+            ): Config {
+                throw new BadMethodCallException('ConfigService stub does not support set().');
+            }
+
+            public function has(string $key, ?string $category = null): bool
+            {
+                if ($category !== null) {
+                    return array_key_exists($key, $this->values[$category] ?? []);
+                }
+
+                return array_key_exists($key, $this->values);
+            }
+        };
+
+        Cfg::swap($service);
+    }
+}


### PR DESCRIPTION
## Summary
- add integration tests covering AbstractLoggedMail header generation and content wiring
- verify NewOfferMail and ReminderMail envelopes consume configuration and expose view data
- ensure NoReplyFAQMail stays flagged as an auto-responder with the expected template

## Testing
- ./vendor/bin/phpunit --no-coverage --testsuite=Integration --filter='Tests\\Integration\\Mail'

------
https://chatgpt.com/codex/tasks/task_e_68e825c683c48329a9d88a53c95fd7c5