### PR TITLE
Fix clip selector component and stabilize phpunit configuration

### DIFF
--- a/app/Filament/Pages/VideoUpload.php
+++ b/app/Filament/Pages/VideoUpload.php
@@ -6,10 +6,11 @@ use App\Jobs\ProcessUploadedVideo;
 use App\Models\Clip;
 use BezhanSalleh\FilamentShield\Traits\HasPageShield;
 use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\Hidden;
 use Filament\Forms\Components\Repeater;
-use Filament\Forms\Components\Slider;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\ViewField;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
 use Filament\Notifications\Notification;
@@ -51,19 +52,19 @@ class VideoUpload extends Page implements HasForms
                             ->required()
                             ->acceptedFileTypes(['video/mp4'])
                             ->storeFiles(false),
-                        Slider::make('start_sec')
-                            ->label('Start')
-                            ->minValue(0)
-                            ->maxValue(fn(Get $get) => $get('end_sec') ?? 100)
-                            ->live()
-                            ->formatStateUsing(fn($value) => gmdate('i:s', (int)$value)),
-
-                        Slider::make('end_sec')
-                            ->label('Ende')
-                            ->minValue(fn(Get $get) => $get('start_sec') ?? 0)
-                            ->maxValue(fn(Get $get) => $get('duration') ?? 100)
-                            ->live()
-                            ->formatStateUsing(fn($value) => gmdate('i:s', (int)$value)),
+                        Hidden::make('start_sec')
+                            ->default(0)
+                            ->dehydrated(),
+                        Hidden::make('end_sec')
+                            ->default(null)
+                            ->dehydrated(),
+                        Hidden::make('duration')
+                            ->default(null)
+                            ->dehydrated(false),
+                        ViewField::make('clip_selector')
+                            ->view('filament.forms.components.clip-selector')
+                            ->columnSpanFull()
+                            ->visible(fn(Get $get) => filled($get('file'))),
                         Textarea::make('note')->label('Notiz')
                             ->rows(5)
                             ->autosize()

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,14 +11,6 @@
          failOnPhpunitDeprecation="true"
          failOnIncomplete="true"
 >
-    <coverage
-            includeUncoveredFiles="true"
-            pathCoverage="false"
-    >
-        <report>
-            <clover outputFile="coverage/clover.xml"/>
-        </report>
-    </coverage>
     <testsuites>
         <testsuite name="Unit">
             <directory>tests/Unit</directory>
@@ -40,6 +32,7 @@
         </exclude>
     </source>
     <php>
+        <ini name="memory_limit" value="512M"/>
         <env name="APP_ENV" value="testing"/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="APP_KEY" value="base64:qX1GPfVCc+DwF6K/By7bLsmonvMfpfKR5esZzEgot2o="/>

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,6 +1,260 @@
 import './bootstrap';
 import ZipDownloader from './components/ZipDownloader';
 
+window.clipSelector = function clipSelector({ startModel, endModel, durationModel }) {
+    return {
+        startModel,
+        endModel,
+        durationModel,
+        sliderInstance: null,
+        videoEl: null,
+        sliderEl: null,
+        videoSource: null,
+        pond: null,
+        hasVideo: false,
+        formattedStart: '00:00',
+        formattedEnd: '00:00',
+
+        async init() {
+            this.videoEl = this.$refs.video;
+            this.sliderEl = this.$refs.slider;
+
+            this.updateFormattedTimes();
+
+            this.$watch('startModel', () => this.syncSliderFromModels());
+            this.$watch('endModel', () => this.syncSliderFromModels());
+            this.$watch('durationModel', () => this.syncSliderFromModels());
+
+            await this.connectToFilePond();
+
+            if (this.durationModel) {
+                this.prepareSlider();
+            }
+        },
+
+        async connectToFilePond() {
+            const repeaterItem = this.$root.closest('.fi-fo-repeater-item');
+
+            if (!repeaterItem) {
+                return;
+            }
+
+            const fileInput = repeaterItem.querySelector('.fi-fo-file-upload input[type="file"]');
+
+            if (!fileInput) {
+                return;
+            }
+
+            const pond = await this.waitForPondInstance(fileInput);
+
+            if (!pond) {
+                return;
+            }
+
+            this.pond = pond;
+
+            pond.on('addfile', (error, file) => {
+                if (error) {
+                    return;
+                }
+
+                this.loadFile(file?.file ?? null);
+            });
+
+            pond.on('removefile', () => {
+                this.reset();
+            });
+
+            const existing = pond
+                .getFiles()
+                .find((candidate) => candidate?.file instanceof File);
+
+            if (existing) {
+                this.loadFile(existing.file);
+            }
+        },
+
+        waitForPondInstance(input) {
+            return new Promise((resolve) => {
+                const lookup = () => {
+                    if (window.FilePond) {
+                        const instance = window.FilePond.find(input);
+
+                        if (instance) {
+                            resolve(instance);
+
+                            return;
+                        }
+                    }
+
+                    requestAnimationFrame(lookup);
+                };
+
+                lookup();
+            });
+        },
+
+        loadFile(file) {
+            if (!(file instanceof File)) {
+                return;
+            }
+
+            this.hasVideo = true;
+
+            if (this.videoSource) {
+                URL.revokeObjectURL(this.videoSource);
+                this.videoSource = null;
+            }
+
+            this.videoSource = URL.createObjectURL(file);
+            this.videoEl.src = this.videoSource;
+            this.videoEl.load();
+
+            this.videoEl.addEventListener(
+                'loadedmetadata',
+                () => {
+                    const duration = Number.isFinite(this.videoEl.duration)
+                        ? Math.max(0, Math.round(this.videoEl.duration))
+                        : 0;
+
+                    this.durationModel = duration || this.durationModel || 0;
+
+                    if (this.startModel == null || this.startModel < 0) {
+                        this.startModel = 0;
+                    }
+
+                    if (this.endModel == null || this.endModel > duration) {
+                        this.endModel = duration;
+                    }
+
+                    this.prepareSlider();
+                    this.updateFormattedTimes();
+                },
+                { once: true },
+            );
+        },
+
+        prepareSlider() {
+            if (!this.sliderEl) {
+                return;
+            }
+
+            const duration = Number(this.durationModel ?? 0);
+            const fallbackExtent = Math.max(
+                Math.round(Number(this.startModel ?? 0)),
+                Math.round(Number(this.endModel ?? 0)),
+                1,
+            );
+            const safeDuration = Number.isFinite(duration) && duration > 0 ? duration : fallbackExtent;
+            const startValue = Math.max(0, Math.min(safeDuration, Number(this.startModel ?? 0)));
+            const endValue = Math.max(startValue, Math.min(safeDuration, Number(this.endModel ?? safeDuration)));
+
+            if (this.sliderInstance) {
+                this.sliderInstance.destroy();
+            }
+
+            const sliderLib = window.noUiSlider;
+
+            if (!sliderLib) {
+                return;
+            }
+
+            this.sliderInstance = sliderLib.create(this.sliderEl, {
+                start: [startValue, endValue],
+                connect: true,
+                behaviour: 'tap-drag',
+                step: 1,
+                range: {
+                    min: 0,
+                    max: safeDuration,
+                },
+            });
+
+            this.sliderInstance.on('update', (values) => {
+                const [start, end] = values.map((value) => Math.max(0, Math.round(Number(value) || 0)));
+
+                if (start !== Math.round(Number(this.startModel ?? 0))) {
+                    this.startModel = start;
+                }
+
+                if (end !== Math.round(Number(this.endModel ?? 0))) {
+                    this.endModel = end;
+                }
+
+                this.updateFormattedTimes();
+            });
+        },
+
+        syncSliderFromModels() {
+            this.updateFormattedTimes();
+
+            if (!this.sliderInstance) {
+                return;
+            }
+
+            const current = this.sliderInstance
+                .get()
+                .map((value) => Math.round(Number(value) || 0));
+            const target = [
+                Math.max(0, Math.round(Number(this.startModel ?? 0))),
+                Math.max(0, Math.round(Number(this.endModel ?? 0))),
+            ];
+
+            if (current[0] !== target[0] || current[1] !== target[1]) {
+                this.sliderInstance.set(target);
+            }
+        },
+
+        updateFormattedTimes() {
+            this.formattedStart = this.formatTime(this.startModel);
+            const endBase = this.endModel ?? this.durationModel ?? 0;
+            this.formattedEnd = this.formatTime(endBase);
+        },
+
+        formatTime(value) {
+            const seconds = Math.max(0, Math.round(Number(value) || 0));
+            const minutes = Math.floor(seconds / 60)
+                .toString()
+                .padStart(2, '0');
+            const secs = (seconds % 60).toString().padStart(2, '0');
+
+            return `${minutes}:${secs}`;
+        },
+
+        reset() {
+            this.hasVideo = false;
+
+            if (this.sliderInstance) {
+                this.sliderInstance.destroy();
+                this.sliderInstance = null;
+            }
+
+            if (this.videoSource) {
+                URL.revokeObjectURL(this.videoSource);
+                this.videoSource = null;
+            }
+
+            this.startModel = 0;
+            this.endModel = null;
+            this.durationModel = null;
+
+            this.updateFormattedTimes();
+        },
+
+        destroy() {
+            if (this.sliderInstance) {
+                this.sliderInstance.destroy();
+                this.sliderInstance = null;
+            }
+
+            if (this.videoSource) {
+                URL.revokeObjectURL(this.videoSource);
+                this.videoSource = null;
+            }
+        },
+    };
+};
+
 
 document.addEventListener('DOMContentLoaded', () => {
     const form = document.getElementById('zipForm');

--- a/resources/views/filament/forms/components/clip-selector.blade.php
+++ b/resources/views/filament/forms/components/clip-selector.blade.php
@@ -1,12 +1,35 @@
-<div x-data="clipSelector()" class="space-y-2" x-init="init()">
-    <video x-ref="video" x-show="showPlayer" x-cloak controls class="w-full"></video>
+@php
+    $basePath = $getContainer()->getStatePath();
+@endphp
+<div
+    x-data="clipSelector({
+        startModel: @entangle("{$basePath}.start_sec").live,
+        endModel: @entangle("{$basePath}.end_sec").live,
+        durationModel: @entangle("{$basePath}.duration").live,
+    })"
+    class="space-y-3"
+    x-init="init()"
+    x-cloak
+>
+    <div class="aspect-video w-full overflow-hidden rounded-lg bg-gray-900" x-show="hasVideo">
+        <video
+            x-ref="video"
+            class="h-full w-full object-contain"
+            playsinline
+            controls
+        ></video>
+    </div>
 
-    <input type="hidden" x-model="start" wire:model.defer="{{ $getStatePath() }}.start_sec">
-    <input type="hidden" x-model="end" wire:model.defer="{{ $getStatePath() }}.end_sec">
+    <div x-ref="sliderWrapper" x-show="hasVideo" class="mt-2">
+        <div x-ref="slider" class="h-1 rounded bg-gray-200"></div>
+    </div>
 
-    <div x-ref="slider" class="mt-2 w-full h-2 bg-gray-200 rounded"></div>
-
-    <div class="text-sm">
-        Start: <span x-text="start"></span>s – Ende: <span x-text="end"></span>s
+    <div class="flex items-center justify-between text-sm text-gray-700">
+        <span>
+            Start: <span class="font-mono" x-text="formattedStart"></span>
+        </span>
+        <span>
+            Ende: <span class="font-mono" x-text="formattedEnd"></span>
+        </span>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- switch the video upload page to use Filament's `ViewField` component for the clip selector so the page renders during tests
- remove the unused code coverage configuration and raise the phpunit memory limit to prevent the suite from exhausting memory

## Testing
- php artisan test
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68ec1d27e5948329aa7a104cd0f7c6e5