### PR TITLE
Add user-scoped read-only video resource for standard panel

### DIFF
--- a/app/Filament/Standard/Resources/VideoResource.php
+++ b/app/Filament/Standard/Resources/VideoResource.php
@@ -2,93 +2,170 @@
 
 namespace App\Filament\Standard\Resources;
 
+use App\Enum\StatusEnum;
 use App\Filament\Standard\Resources\VideoResource\Pages;
+use App\Filament\Standard\Resources\VideoResource\RelationManagers\AssignmentsRelationManager;
 use App\Models\Video;
-use BackedEnum;
-use Filament\Actions;
-use Filament\Forms;
+use Filament\Infolists\Components\Grid;
+use Filament\Infolists\Components\ImageEntry;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Infolists\Infolist;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
-use Filament\Support\Icons\Heroicon;
-use Filament\Tables;
+use Filament\Tables\Actions\ViewAction;
+use Filament\Tables\Columns\ImageColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 
 class VideoResource extends Resource
 {
     protected static ?string $model = Video::class;
 
-    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedRectangleStack;
+    protected static ?string $modelLabel = 'Video';
 
-    protected static ?string $recordTitleAttribute = 'Videos';
+    protected static ?string $pluralModelLabel = 'Videos';
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-film';
+
+    protected static ?string $recordTitleAttribute = 'original_name';
 
     public static function form(Schema $schema): Schema
     {
         return $schema
-            ->components([
-                Forms\Components\TextInput::make('hash')
-                    ->required(),
-                Forms\Components\TextInput::make('ext'),
-                Forms\Components\TextInput::make('original_name'),
-                Forms\Components\TextInput::make('bytes')
-                    ->numeric(),
-                Forms\Components\TextInput::make('path')
-                    ->required(),
-                Forms\Components\TextInput::make('disk')
-                    ->required()
-                    ->default('local'),
-                Forms\Components\Textarea::make('meta')
-                    ->columnSpanFull(),
-                Forms\Components\TextInput::make('preview_url')
-                    ->url(),
+            ->components([]);
+    }
+
+    public static function infolist(Infolist $infolist): Infolist
+    {
+        return $infolist
+            ->schema([
+                Grid::make()
+                    ->columns([
+                        'md' => 2,
+                    ])
+                    ->schema([
+                        ImageEntry::make('preview_url')
+                            ->label('Vorschau')
+                            ->visible(fn(Video $record) => filled($record->getAttribute('preview_url')))
+                            ->columnSpan(1)
+                            ->extraImgAttributes(['class' => 'rounded-lg shadow-md w-full max-w-xs']),
+                        Grid::make()
+                            ->schema([
+                                TextEntry::make('original_name')
+                                    ->label('Video-Titel')
+                                    ->extraAttributes(['class' => 'text-lg font-semibold']),
+                                TextEntry::make('duration')
+                                    ->label('Dauer')
+                                    ->state(fn(Video $record) => self::formatDuration($record->getAttribute('duration'))),
+                                TextEntry::make('created_at')
+                                    ->label('Upload am')
+                                    ->dateTime('d.m.Y, H:i'),
+                                TextEntry::make('status_label')
+                                    ->label('Status')
+                                    ->badge()
+                                    ->state(fn(Video $record) => self::determineStatusLabel($record))
+                                    ->color(fn(Video $record) => self::statusColor(self::determineStatusLabel($record)))
+                                    ->icon(fn(Video $record) => self::statusIcon(self::determineStatusLabel($record))),
+                                TextEntry::make('available_assignments_count')
+                                    ->label('Verfügbare Offers'),
+                                TextEntry::make('expired_assignments_count')
+                                    ->label('Abgelaufene Offers'),
+                            ])
+                            ->columns(2),
+                    ]),
             ]);
     }
 
     public static function table(Table $table): Table
     {
         return $table
-            ->recordTitleAttribute('Videos')
+            ->defaultSort('created_at', 'desc')
+            ->recordUrl(fn(Video $record) => static::getUrl('view', ['record' => $record]))
             ->columns([
-                Tables\Columns\TextColumn::make('hash')
-                    ->searchable(),
-                Tables\Columns\TextColumn::make('ext')
-                    ->searchable(),
-                Tables\Columns\TextColumn::make('original_name')
-                    ->searchable(),
-                Tables\Columns\TextColumn::make('bytes')
-                    ->numeric()
+                ImageColumn::make('preview_url')
+                    ->label('Vorschau')
+                    ->size(48)
+                    ->circular()
+                    ->visible(fn(Video $record) => filled($record->getAttribute('preview_url')))
+                    ->getStateUsing(fn(Video $record) => (string) $record->getAttribute('preview_url')),
+
+                TextColumn::make('original_name')
+                    ->label('Video-Titel')
+                    ->description('Meine hochgeladenen Clips')
+                    ->sortable()
+                    ->searchable()
+                    ->limit(60),
+
+                TextColumn::make('duration')
+                    ->label('Dauer')
+                    ->state(fn(Video $record) => self::formatDuration($record->getAttribute('duration')))
+                    ->tooltip('Gesamtlänge des Videos')
                     ->sortable(),
-                Tables\Columns\TextColumn::make('path')
-                    ->searchable(),
-                Tables\Columns\TextColumn::make('disk')
-                    ->searchable(),
-                Tables\Columns\TextColumn::make('preview_url')
-                    ->searchable(),
-                Tables\Columns\TextColumn::make('created_at')
-                    ->dateTime()
-                    ->sortable()
-                    ->toggleable(isToggledHiddenByDefault: true),
-                Tables\Columns\TextColumn::make('updated_at')
-                    ->dateTime()
-                    ->sortable()
-                    ->toggleable(isToggledHiddenByDefault: true),
+
+                TextColumn::make('created_at')
+                    ->label('Upload am')
+                    ->dateTime('d.m.Y, H:i')
+                    ->sortable(),
+
+                TextColumn::make('status_label')
+                    ->label('Status')
+                    ->badge()
+                    ->state(fn(Video $record) => self::determineStatusLabel($record))
+                    ->color(fn(Video $record) => self::statusColor(self::determineStatusLabel($record)))
+                    ->icon(fn(Video $record) => self::statusIcon(self::determineStatusLabel($record)))
+                    ->sortable(query: fn(Builder $query, string $direction) => $query->orderBy('available_assignments_count', $direction)),
+
+                TextColumn::make('available_assignments_count')
+                    ->label('Verfügbare Offers')
+                    ->sortable(),
+
+                TextColumn::make('expired_assignments_count')
+                    ->label('Abgelaufene Offers')
+                    ->sortable(),
             ])
             ->filters([
-                //
+                SelectFilter::make('assignment_state')
+                    ->label('Offer-Status')
+                    ->options([
+                        'active' => 'Nur aktive Offers',
+                        'expired' => 'Abgelaufene Offers',
+                        'all' => 'Alle',
+                    ])
+                    ->default('all')
+                    ->query(function (Builder $query, array $data): Builder {
+                        return match ($data['value'] ?? 'all') {
+                            'active' => $query->whereHas('assignments', function (Builder $assignmentQuery) {
+                                $assignmentQuery
+                                    ->whereIn('status', StatusEnum::getReadyStatus())
+                                    ->where(function (Builder $expiryQuery) {
+                                        $expiryQuery
+                                            ->whereNull('expires_at')
+                                            ->orWhere('expires_at', '>', now());
+                                    });
+                            }),
+                            'expired' => $query->whereHas('assignments', fn(Builder $assignmentQuery) => $assignmentQuery->where('status', StatusEnum::EXPIRED->value)),
+                            default => $query,
+                        };
+                    }),
             ])
             ->recordActions([
-                Actions\EditAction::make(),
+                ViewAction::make('view-details')
+                    ->label('Details ansehen')
+                    ->icon('heroicon-m-eye')
+                    ->button(),
             ])
-            ->toolbarActions([
-                Actions\BulkActionGroup::make([
-                    Actions\DeleteBulkAction::make(),
-                ]),
-            ]);
+            ->toolbarActions([])
+            ->emptyStateHeading('Keine Videos gefunden')
+            ->emptyStateDescription('Hier siehst du alle Videos, die deinem Account gehören.');
     }
 
     public static function getRelations(): array
     {
         return [
-            //
+            AssignmentsRelationManager::class,
         ];
     }
 
@@ -96,8 +173,87 @@ class VideoResource extends Resource
     {
         return [
             'index' => Pages\ListVideos::route('/'),
-            'create' => Pages\CreateVideo::route('/create'),
-            'edit' => Pages\EditVideo::route('/{record}/edit'),
+            'view' => Pages\ViewVideo::route('/{record}'),
         ];
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->where('user_id', auth()->id())
+            ->withCount([
+                'assignments as available_assignments_count' => function (Builder $query) {
+                    $query
+                        ->whereIn('status', StatusEnum::getReadyStatus())
+                        ->where(function (Builder $expiryQuery) {
+                            $expiryQuery
+                                ->whereNull('expires_at')
+                                ->orWhere('expires_at', '>', now());
+                        });
+                },
+                'assignments as expired_assignments_count' => fn(Builder $query) => $query->where('status', StatusEnum::EXPIRED->value),
+                'assignments as assignments_count',
+            ]);
+    }
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    public static function canEdit(Model $record): bool
+    {
+        return false;
+    }
+
+    public static function canDelete(Model $record): bool
+    {
+        return false;
+    }
+
+    private static function formatDuration(?int $duration): string
+    {
+        if (!$duration || $duration <= 0) {
+            return '–';
+        }
+
+        $minutes = intdiv($duration, 60);
+        $seconds = $duration % 60;
+
+        return sprintf('%d:%02d', $minutes, $seconds);
+    }
+
+    private static function determineStatusLabel(Video $video): string
+    {
+        $available = (int) $video->getAttribute('available_assignments_count');
+        $expired = (int) $video->getAttribute('expired_assignments_count');
+        $total = (int) $video->getAttribute('assignments_count');
+
+        return match (true) {
+            $available > 0 => 'Verfügbar',
+            $expired > 0 => 'Abgelaufen',
+            $total > 0 && $available === 0 => 'Alle verteilt',
+            default => 'In Vorbereitung',
+        };
+    }
+
+    private static function statusColor(string $label): string
+    {
+        return match ($label) {
+            'Verfügbar' => 'success',
+            'Alle verteilt' => 'primary',
+            'Abgelaufen' => 'gray',
+            default => 'warning',
+        };
+    }
+
+    private static function statusIcon(string $label): string
+    {
+        return match ($label) {
+            'Verfügbar' => 'heroicon-m-sparkles',
+            'Alle verteilt' => 'heroicon-m-check-badge',
+            'Abgelaufen' => 'heroicon-m-clock',
+            default => 'heroicon-m-arrow-path',
+        };
     }
 }

--- a/app/Filament/Standard/Resources/VideoResource/Pages/ListVideos.php
+++ b/app/Filament/Standard/Resources/VideoResource/Pages/ListVideos.php
@@ -3,7 +3,7 @@
 namespace App\Filament\Standard\Resources\VideoResource\Pages;
 
 use App\Filament\Standard\Resources\VideoResource;
-use Filament\Actions;
+use App\Filament\Standard\Resources\VideoResource\Widgets\VideoStatsOverview;
 use Filament\Resources\Pages\ListRecords;
 
 class ListVideos extends ListRecords
@@ -12,8 +12,13 @@ class ListVideos extends ListRecords
 
     protected function getHeaderActions(): array
     {
+        return [];
+    }
+
+    protected function getHeaderWidgets(): array
+    {
         return [
-            Actions\CreateAction::make(),
+            VideoStatsOverview::class,
         ];
     }
 }

--- a/app/Filament/Standard/Resources/VideoResource/Pages/ViewVideo.php
+++ b/app/Filament/Standard/Resources/VideoResource/Pages/ViewVideo.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Filament\Standard\Resources\VideoResource\Pages;
+
+use App\Filament\Standard\Resources\VideoResource;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewVideo extends ViewRecord
+{
+    protected static string $resource = VideoResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/app/Filament/Standard/Resources/VideoResource/RelationManagers/AssignmentsRelationManager.php
+++ b/app/Filament/Standard/Resources/VideoResource/RelationManagers/AssignmentsRelationManager.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace App\Filament\Standard\Resources\VideoResource\RelationManagers;
+
+use App\Enum\StatusEnum;
+use App\Models\Assignment;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
+
+class AssignmentsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'assignments';
+
+    protected static ?string $title = 'Assignments';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->modifyQueryUsing(fn(Builder $query) => $query->with(['channel', 'downloads']))
+            ->recordTitleAttribute('id')
+            ->columns([
+                TextColumn::make('channel.name')
+                    ->label('Channel')
+                    ->description('Ziel-Channel für dieses Angebot')
+                    ->icon('heroicon-m-link')
+                    ->limit(30)
+                    ->toggleable(),
+
+                TextColumn::make('status')
+                    ->label('Status')
+                    ->badge()
+                    ->icon(fn(string $state) => $this->statusIcon($state))
+                    ->color(fn(string $state) => $this->statusColor($state))
+                    ->sortable(),
+
+                TextColumn::make('expires_at')
+                    ->label('Gültig bis')
+                    ->dateTime('d.m.Y H:i')
+                    ->description('Offer-Link läuft ab')
+                    ->sortable(),
+
+                TextColumn::make('download_state')
+                    ->label('Download-Status')
+                    ->state(fn(Assignment $record) => $this->downloadLabel($record))
+                    ->icon(fn(Assignment $record) => $this->downloadIcon($record))
+                    ->color(fn(Assignment $record) => $this->downloadColor($record))
+                    ->wrap(),
+            ])
+            ->filters([
+                SelectFilter::make('status')
+                    ->label('Status filtern')
+                    ->options([
+                        StatusEnum::QUEUED->value => 'Offen',
+                        StatusEnum::NOTIFIED->value => 'Verfügbar',
+                        StatusEnum::PICKEDUP->value => 'Angenommen',
+                        StatusEnum::REJECTED->value => 'Zurückgegeben',
+                        StatusEnum::EXPIRED->value => 'Abgelaufen',
+                    ]),
+            ])
+            ->headerActions([])
+            ->recordActions([])
+            ->emptyStateHeading('Keine Assignments vorhanden')
+            ->emptyStateDescription('Sobald dieses Video verteilt wird, siehst du hier alle Offers.');
+    }
+
+    private function downloadLabel(Assignment $assignment): string
+    {
+        $latestDownload = $assignment->downloads->sortByDesc('downloaded_at')->first();
+
+        if ($assignment->status === StatusEnum::REJECTED->value) {
+            return 'Zurückgegeben';
+        }
+
+        if ($assignment->status === StatusEnum::EXPIRED->value) {
+            return 'Abgelaufen';
+        }
+
+        if ($latestDownload?->downloaded_at) {
+            return 'Heruntergeladen am ' . Carbon::parse($latestDownload->downloaded_at)->isoFormat('DD.MM.YYYY HH:mm');
+        }
+
+        return 'Noch nicht heruntergeladen';
+    }
+
+    private function downloadIcon(Assignment $assignment): string
+    {
+        return match (true) {
+            $assignment->status === StatusEnum::REJECTED->value => 'heroicon-m-arrow-uturn-left',
+            $assignment->status === StatusEnum::EXPIRED->value => 'heroicon-m-clock',
+            $assignment->downloads->isNotEmpty() => 'heroicon-m-arrow-down-tray',
+            default => 'heroicon-m-bell',
+        };
+    }
+
+    private function downloadColor(Assignment $assignment): string
+    {
+        return match (true) {
+            $assignment->status === StatusEnum::REJECTED->value => 'warning',
+            $assignment->status === StatusEnum::EXPIRED->value => 'gray',
+            $assignment->downloads->isNotEmpty() => 'success',
+            default => 'primary',
+        };
+    }
+
+    private function statusIcon(string $status): string
+    {
+        return match ($status) {
+            StatusEnum::NOTIFIED->value, StatusEnum::QUEUED->value => 'heroicon-m-sparkles',
+            StatusEnum::PICKEDUP->value => 'heroicon-m-check-circle',
+            StatusEnum::REJECTED->value => 'heroicon-m-arrow-uturn-left',
+            StatusEnum::EXPIRED->value => 'heroicon-m-clock',
+            default => 'heroicon-m-information-circle',
+        };
+    }
+
+    private function statusColor(string $status): string
+    {
+        return match ($status) {
+            StatusEnum::NOTIFIED->value, StatusEnum::QUEUED->value => 'success',
+            StatusEnum::PICKEDUP->value => 'primary',
+            StatusEnum::REJECTED->value => 'warning',
+            StatusEnum::EXPIRED->value => 'gray',
+            default => 'gray',
+        };
+    }
+}

--- a/app/Filament/Standard/Resources/VideoResource/Widgets/VideoStatsOverview.php
+++ b/app/Filament/Standard/Resources/VideoResource/Widgets/VideoStatsOverview.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Filament\Standard\Resources\VideoResource\Widgets;
+
+use App\Enum\StatusEnum;
+use App\Models\Assignment;
+use App\Models\Video;
+use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+
+class VideoStatsOverview extends BaseWidget
+{
+    protected function getStats(): array
+    {
+        $userId = auth()->id();
+
+        $videoQuery = Video::query()->where('user_id', $userId);
+        $assignmentQuery = Assignment::query()->whereHas('video', fn($query) => $query->where('user_id', $userId));
+
+        $videoCount = $videoQuery->count();
+        $availableOffers = (clone $assignmentQuery)
+            ->whereIn('status', StatusEnum::getReadyStatus())
+            ->where(function ($query) {
+                $query
+                    ->whereNull('expires_at')
+                    ->orWhere('expires_at', '>', now());
+            })
+            ->count();
+        $expiredOffers = (clone $assignmentQuery)
+            ->where('status', StatusEnum::EXPIRED->value)
+            ->count();
+
+        return [
+            Stat::make('Videos', number_format($videoCount))
+                ->description('Videos insgesamt')
+                ->color('primary')
+                ->icon('heroicon-m-film'),
+
+            Stat::make('Verfügbare Offers', number_format($availableOffers))
+                ->description('bereit zum Versenden')
+                ->color('success')
+                ->icon('heroicon-m-sparkles'),
+
+            Stat::make('Abgelaufene Offers', number_format($expiredOffers))
+                ->description('nicht mehr aktiv')
+                ->color('gray')
+                ->icon('heroicon-m-clock'),
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- add a read-only video resource for the standard panel with user scoping, status badges, filters, and formatted durations
- include an assignments relation manager that surfaces channel, offer status, and download state without edit actions
- provide a stats overview widget and view page to give end users quick totals and detailed video info

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69224d19328c832998bf5e602c4f1e07)