### PR TITLE
Add uploader-aware channel quotas

### DIFF
--- a/app/DTO/ChannelPoolDto.php
+++ b/app/DTO/ChannelPoolDto.php
@@ -13,7 +13,9 @@ class ChannelPoolDto
         public Collection $channels,
         public Collection $rotationPool,
         /** @var array<int,int> channel_id => quota */
-        public array $quota,
+        public array $channelQuota,
+        /** @var array<int,array<int|string,int>> channel_id => [uploader_id => quota] */
+        public array $uploaderQuotaMatrix,
     ) {
     }
 }

--- a/app/Repository/BatchRepository.php
+++ b/app/Repository/BatchRepository.php
@@ -9,13 +9,20 @@ use App\Models\Batch;
 
 class BatchRepository
 {
-    public function markAssignedBatchAsFinished(Batch $batch, int $assigned, int $skipped): bool
-    {
+    public function markAssignedBatchAsFinished(
+        Batch $batch,
+        int $assigned,
+        int $skipped,
+        array $assignedByUploader = [],
+        array $skippedByBlock = []
+    ): bool {
         return $batch->update([
             'finished_at' => now(),
             'stats' => [
                 'assigned' => $assigned,
                 'skipped' => $skipped,
+                'assigned_by_uploader' => $assignedByUploader,
+                'skipped_by_block' => $skippedByBlock,
             ],
         ]);
     }

--- a/app/Services/AssignmentService.php
+++ b/app/Services/AssignmentService.php
@@ -94,11 +94,17 @@ readonly class AssignmentService
     public function assignGroupToChannel(Collection $group, Channel $channel, AssignmentRun $run): int
     {
         $count = 0;
+        $firstVideo = $group->first();
+        $uploaderId = $firstVideo?->clips->first()?->user_id ?? $run->uploaderId;
+        $groupCount = $group->count();
+        $run->recordAssignmentStats($channel->getKey(), $uploaderId, $groupCount);
+
         foreach ($group as $video) {
             $this->assignmentRepository->createAssignment($video, $channel, $run->batch);
 
             $run->recordAssignment($video->getKey(), $channel->getKey());
-            $run->decrementQuota($channel->getKey());
+            $run->decrementUploaderQuota($channel->getKey(), $uploaderId);
+            $run->decrementChannelQuota($channel->getKey());
             $count++;
         }
 

--- a/app/Services/BatchService.php
+++ b/app/Services/BatchService.php
@@ -83,9 +83,20 @@ class BatchService
         ]);
     }
 
-    public function finishAssignBatch(Batch $batch, int $assigned, int $skipped): bool
-    {
-        return $this->batchRepository->markAssignedBatchAsFinished($batch, $assigned, $skipped);
+    public function finishAssignBatch(
+        Batch $batch,
+        int $assigned,
+        int $skipped,
+        array $assignedByUploader = [],
+        array $skippedByBlock = []
+    ): bool {
+        return $this->batchRepository->markAssignedBatchAsFinished(
+            $batch,
+            $assigned,
+            $skipped,
+            $assignedByUploader,
+            $skippedByBlock
+        );
     }
 
 


### PR DESCRIPTION
## Summary
- build a shared channel/uploader quota matrix for each distribution run
- enforce uploader-level quotas during channel selection and assignment
- record assignment and block statistics per uploader while updating batch stats

## Testing
- php -l app/DTO/ChannelPoolDto.php
- php -l app/Services/ChannelService.php
- php -l app/ValueObjects/AssignmentRun.php
- php -l app/Services/AssignmentService.php
- php -l app/Services/AssignmentDistributor.php
- php -l app/Repository/BatchRepository.php
- php -l app/Services/BatchService.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692613c3cbc083298ffcdb2c7fe37da1)