### PR TITLE
Add team channel quota overrides for assignments

### DIFF
--- a/app/DTO/UploaderPoolInfo.php
+++ b/app/DTO/UploaderPoolInfo.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO;
+
+use Illuminate\Support\Collection;
+
+class UploaderPoolInfo
+{
+    public function __construct(
+        public string $type,
+        public string|int $id,
+        public Collection $videos,
+    ) {
+    }
+}

--- a/app/ValueObjects/AssignmentRun.php
+++ b/app/ValueObjects/AssignmentRun.php
@@ -16,7 +16,8 @@ class AssignmentRun
         public readonly array $blockedByVideo,
         public array $assignedChannelsByVideo,
         public readonly Batch $batch,
-        public readonly string|int $uploaderId
+        public readonly string $uploaderType,
+        public readonly string|int $uploaderId,
     ) {
     }
 

--- a/tests/Integration/Services/ChannelServiceTest.php
+++ b/tests/Integration/Services/ChannelServiceTest.php
@@ -40,7 +40,7 @@ class ChannelServiceTest extends DatabaseTestCase
         ]);
 
         // Act
-        $dto = $this->channelService->prepareChannelsAndPool(null);
+        $dto = $this->channelService->prepareChannelsAndPool(null, 'user', 0);
 
         // Assert
         $this->assertCount(2, $dto->channels);
@@ -70,7 +70,7 @@ class ChannelServiceTest extends DatabaseTestCase
         $quotaOverride = 42;
 
         // Act
-        $dto = $this->channelService->prepareChannelsAndPool($quotaOverride);
+        $dto = $this->channelService->prepareChannelsAndPool($quotaOverride, 'user', 0);
 
         // Assert
         $this->assertCount(2, $dto->channels);


### PR DESCRIPTION
## Summary
- introduce uploader pool DTOs and propagate uploader type/id through assignment runs
- apply team-specific channel quota overrides from pivot data when assigning for teams
- update assignment and channel preparation flows to use new uploader context

## Testing
- php -l app/Services/ChannelService.php
- php -l app/Services/AssignmentDistributor.php
- php -l app/Repository/VideoRepository.php
- php -l app/ValueObjects/AssignmentRun.php
- php -l app/DTO/UploaderPoolInfo.php
- ./vendor/bin/phpunit --filter ChannelServiceTest *(fails: executable missing in environment)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69261c0e4284832995787d373d41561d)