### PR TITLE
Add feature tests for standard video resource pages

### DIFF
--- a/tests/Feature/Filament/Standard/Resources/VideoResource/Pages/CreateVideoTest.php
+++ b/tests/Feature/Filament/Standard/Resources/VideoResource/Pages/CreateVideoTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament\Standard\Resources\VideoResource\Pages;
+
+use App\Enum\Guard\GuardEnum;
+use App\Enum\PanelEnum;
+use App\Filament\Standard\Resources\VideoResource\Pages\CreateVideo;
+use App\Models\User;
+use App\Repository\TeamRepository;
+use Filament\Facades\Filament;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Permission;
+use Tests\DatabaseTestCase;
+
+final class CreateVideoTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $user = User::factory()
+            ->withOwnTeam()
+            ->admin(GuardEnum::STANDARD)
+            ->create();
+
+        $tenant = app(TeamRepository::class)->getDefaultTeamForUser($user);
+
+        Filament::setCurrentPanel(PanelEnum::STANDARD->value);
+        Filament::setTenant($tenant, true);
+        Filament::auth()->login($user);
+        $this->actingAs($user, GuardEnum::STANDARD->value);
+
+        $this->grantVideoPermissions($user);
+    }
+
+    public function testCreateVideoPageIsAccessible(): void
+    {
+        Livewire::test(CreateVideo::class)
+            ->assertStatus(200);
+    }
+
+    private function grantVideoPermissions(User $user): void
+    {
+        $permissions = [
+            'ViewAny:Video',
+            'Create:Video',
+        ];
+
+        foreach ($permissions as $permission) {
+            Permission::findOrCreate($permission, GuardEnum::STANDARD->value);
+        }
+
+        $user->givePermissionTo($permissions);
+    }
+}

--- a/tests/Feature/Filament/Standard/Resources/VideoResource/Pages/EditVideoTest.php
+++ b/tests/Feature/Filament/Standard/Resources/VideoResource/Pages/EditVideoTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament\Standard\Resources\VideoResource\Pages;
+
+use App\Enum\Guard\GuardEnum;
+use App\Enum\PanelEnum;
+use App\Filament\Standard\Resources\VideoResource\Pages\EditVideo;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Video;
+use App\Repository\TeamRepository;
+use Filament\Facades\Filament;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Permission;
+use Tests\DatabaseTestCase;
+
+final class EditVideoTest extends DatabaseTestCase
+{
+    private User $user;
+
+    private Team $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()
+            ->withOwnTeam()
+            ->admin(GuardEnum::STANDARD)
+            ->create();
+
+        $this->tenant = app(TeamRepository::class)->getDefaultTeamForUser($this->user);
+
+        Filament::setCurrentPanel(PanelEnum::STANDARD->value);
+        Filament::setTenant($this->tenant, true);
+        Filament::auth()->login($this->user);
+        $this->actingAs($this->user, GuardEnum::STANDARD->value);
+        $this->grantVideoPermissions();
+    }
+
+    public function testEditVideoPageShowsDeleteAction(): void
+    {
+        $video = Video::factory()
+            ->for($this->tenant, 'team')
+            ->withClips(1, $this->user)
+            ->create();
+
+        Livewire::test(EditVideo::class, ['record' => $video->getKey()])
+            ->assertStatus(200)
+            ->assertActionVisible('delete');
+    }
+
+    private function grantVideoPermissions(): void
+    {
+        $permissions = [
+            'ViewAny:Video',
+            'View:Video',
+            'Update:Video',
+            'Delete:Video',
+        ];
+
+        foreach ($permissions as $permission) {
+            Permission::findOrCreate($permission, GuardEnum::STANDARD->value);
+        }
+
+        $this->user->givePermissionTo($permissions);
+    }
+}

--- a/tests/Feature/Filament/Standard/Resources/VideoResource/Pages/ViewVideoTest.php
+++ b/tests/Feature/Filament/Standard/Resources/VideoResource/Pages/ViewVideoTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament\Standard\Resources\VideoResource\Pages;
+
+use App\Enum\Guard\GuardEnum;
+use App\Enum\PanelEnum;
+use App\Enum\StatusEnum;
+use App\Filament\Standard\Resources\VideoResource\Pages\ViewVideo;
+use App\Models\Assignment;
+use App\Models\Clip;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Video;
+use App\Repository\TeamRepository;
+use Filament\Facades\Filament;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Permission;
+use Tests\DatabaseTestCase;
+
+final class ViewVideoTest extends DatabaseTestCase
+{
+    private User $user;
+
+    private Team $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()
+            ->withOwnTeam()
+            ->admin(GuardEnum::STANDARD)
+            ->create();
+
+        $this->tenant = app(TeamRepository::class)->getDefaultTeamForUser($this->user);
+
+        Filament::setCurrentPanel(PanelEnum::STANDARD->value);
+        Filament::setTenant($this->tenant, true);
+        Filament::auth()->login($this->user);
+        $this->actingAs($this->user, GuardEnum::STANDARD->value);
+        $this->grantVideoPermissions();
+    }
+
+    public function testViewVideoShowsFormattedDurationAndStatus(): void
+    {
+        $video = Video::factory()
+            ->for($this->tenant, 'team')
+            ->create(['original_name' => 'Awesome Clip.mp4']);
+
+        Clip::factory()
+            ->for($video)
+            ->forUser($this->user)
+            ->range(0, 65)
+            ->create(['bundle_key' => 'bundle-123']);
+
+        Assignment::factory()
+            ->forVideo($video)
+            ->withBatch()
+            ->state([
+                'status' => StatusEnum::QUEUED->value,
+                'expires_at' => now()->addDays(2),
+            ])
+            ->create();
+
+        Livewire::test(ViewVideo::class, ['record' => $video->getKey()])
+            ->assertStatus(200)
+            ->assertSeeText('Awesome Clip.mp4')
+            ->assertSeeText('1:05')
+            ->assertSeeText('Verfügbar');
+    }
+
+    private function grantVideoPermissions(): void
+    {
+        $permissions = [
+            'ViewAny:Video',
+            'View:Video',
+        ];
+
+        foreach ($permissions as $permission) {
+            Permission::findOrCreate($permission, GuardEnum::STANDARD->value);
+        }
+
+        $this->user->givePermissionTo($permissions);
+    }
+}

--- a/tests/Feature/Filament/Standard/Resources/VideoResourceTest.php
+++ b/tests/Feature/Filament/Standard/Resources/VideoResourceTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament\Standard\Resources;
+
+use App\Enum\Guard\GuardEnum;
+use App\Enum\PanelEnum;
+use App\Enum\StatusEnum;
+use App\Filament\Standard\Resources\VideoResource\Pages\ListVideos;
+use App\Models\Assignment;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Video;
+use App\Repository\TeamRepository;
+use Filament\Facades\Filament;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Permission;
+use Tests\DatabaseTestCase;
+
+final class VideoResourceTest extends DatabaseTestCase
+{
+    private User $user;
+
+    private Team $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()
+            ->withOwnTeam()
+            ->admin(GuardEnum::STANDARD)
+            ->create();
+
+        $this->tenant = app(TeamRepository::class)->getDefaultTeamForUser($this->user);
+
+        Filament::setCurrentPanel(PanelEnum::STANDARD->value);
+        Filament::setTenant($this->tenant, true);
+        Filament::auth()->login($this->user);
+        $this->actingAs($this->user, GuardEnum::STANDARD->value);
+        $this->grantVideoPermissions();
+    }
+
+    public function testListVideosShowsOnlyAuthenticatedUsersRecords(): void
+    {
+        $ownVideo = Video::factory()
+            ->for($this->tenant, 'team')
+            ->withClips(1, $this->user)
+            ->create(['original_name' => 'My Clip.mp4']);
+
+        $otherVideo = Video::factory()
+            ->withClips(1)
+            ->create(['original_name' => 'Other Clip.mp4']);
+
+        Livewire::test(ListVideos::class)
+            ->assertStatus(200)
+            ->assertCanSeeTableRecords([$ownVideo])
+            ->assertCanNotSeeTableRecords([$otherVideo]);
+    }
+
+    public function testAssignmentStateFilterKeepsOnlyActiveOffers(): void
+    {
+        $activeVideo = Video::factory()
+            ->for($this->tenant, 'team')
+            ->withClips(1, $this->user)
+            ->create();
+
+        $expiredVideo = Video::factory()
+            ->for($this->tenant, 'team')
+            ->withClips(1, $this->user)
+            ->create();
+
+        Assignment::factory()
+            ->forVideo($activeVideo)
+            ->withBatch()
+            ->state(['status' => StatusEnum::QUEUED->value, 'expires_at' => now()->addDay()])
+            ->create();
+
+        Assignment::factory()
+            ->forVideo($expiredVideo)
+            ->withBatch()
+            ->state(['status' => StatusEnum::EXPIRED->value, 'expires_at' => now()->subDay()])
+            ->create();
+
+        Livewire::test(ListVideos::class)
+            ->set('tableFilters.assignment_state.value', 'active')
+            ->assertCanSeeTableRecords([$activeVideo])
+            ->assertCanNotSeeTableRecords([$expiredVideo]);
+    }
+
+    public function testListVideosShowsStatusAndAssignmentCounts(): void
+    {
+        $video = Video::factory()
+            ->for($this->tenant, 'team')
+            ->withClips(1, $this->user)
+            ->create();
+
+        Assignment::factory()
+            ->forVideo($video)
+            ->withBatch()
+            ->state(['status' => StatusEnum::PICKEDUP->value])
+            ->create();
+
+        Assignment::factory()
+            ->forVideo($video)
+            ->withBatch()
+            ->state(['status' => StatusEnum::EXPIRED->value])
+            ->create();
+
+        Livewire::test(ListVideos::class)
+            ->assertStatus(200)
+            ->assertTableColumnExists('status_label')
+            ->assertTableColumnExists('available_assignments_count')
+            ->assertTableColumnExists('expired_assignments_count')
+            ->assertSeeText('Heruntergeladen');
+    }
+
+    private function grantVideoPermissions(): void
+    {
+        $permissions = [
+            'ViewAny:Video',
+            'View:Video',
+            'Create:Video',
+            'Update:Video',
+            'Delete:Video',
+        ];
+
+        foreach ($permissions as $permission) {
+            Permission::findOrCreate($permission, GuardEnum::STANDARD->value);
+        }
+
+        $this->user->givePermissionTo($permissions);
+    }
+}


### PR DESCRIPTION
## Summary
- add feature coverage for the standard VideoResource list page including filters and status counts
- add page-specific tests for viewing, editing, and creating standard video records with proper permissions

## Testing
- ./vendor/bin/phpunit --no-coverage tests/Feature/Filament/Standard/Resources

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b6a6c3a2c8329983048905ebad7ab)