### PR TITLE
Add integration tests for standard video resource

### DIFF
--- a/tests/Integration/Filament/Standard/Resources/VideoResource/RelationManagers/AssignmentsRelationManagerTest.php
+++ b/tests/Integration/Filament/Standard/Resources/VideoResource/RelationManagers/AssignmentsRelationManagerTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Filament\Standard\Resources\VideoResource\RelationManagers;
+
+use App\Enum\Guard\GuardEnum;
+use App\Enum\PanelEnum;
+use App\Enum\StatusEnum;
+use App\Enum\BatchTypeEnum;
+use App\Filament\Standard\Resources\VideoResource\Pages\ViewVideo;
+use App\Filament\Standard\Resources\VideoResource\RelationManagers\AssignmentsRelationManager;
+use App\Models\Assignment;
+use App\Models\Batch;
+use App\Models\Channel;
+use App\Models\Clip;
+use App\Models\Download;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Video;
+use App\Repository\TeamRepository;
+use Filament\Facades\Filament;
+use Illuminate\Support\Carbon;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Permission;
+use Tests\DatabaseTestCase;
+
+final class AssignmentsRelationManagerTest extends DatabaseTestCase
+{
+    private User $user;
+
+    private Team $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()
+            ->withOwnTeam()
+            ->admin(GuardEnum::STANDARD)
+            ->create();
+
+        $this->tenant = app(TeamRepository::class)->getDefaultTeamForUser($this->user);
+
+        Filament::setCurrentPanel(PanelEnum::STANDARD->value);
+        Filament::setTenant($this->tenant, true);
+        Filament::auth()->login($this->user);
+        $this->actingAs($this->user, GuardEnum::STANDARD->value);
+        $this->grantVideoPermissions();
+    }
+
+    public function testAssignmentsRelationManagerDisplaysDownloadStatesForAssignments(): void
+    {
+        $video = Video::factory()
+            ->for($this->tenant, 'team')
+            ->create();
+
+        Clip::factory()
+            ->for($video)
+            ->forUser($this->user)
+            ->create();
+
+        $batch = Batch::factory()
+            ->type(BatchTypeEnum::ASSIGN->value)
+            ->create();
+
+        $pendingChannel = Channel::factory()->create();
+        $rejectedChannel = Channel::factory()->create();
+        $downloadedChannel = Channel::factory()->create();
+
+        $pendingAssignment = Assignment::factory()
+            ->forVideo($video)
+            ->forChannel($pendingChannel)
+            ->withBatch($batch)
+            ->create([
+                'status' => StatusEnum::QUEUED->value,
+                'expires_at' => Carbon::parse('2030-01-02 10:00:00'),
+            ]);
+
+        $rejectedAssignment = Assignment::factory()
+            ->forVideo($video)
+            ->forChannel($rejectedChannel)
+            ->withBatch($batch)
+            ->create([
+                'status' => StatusEnum::REJECTED->value,
+            ]);
+
+        $downloadedAssignment = Assignment::factory()
+            ->forVideo($video)
+            ->forChannel($downloadedChannel)
+            ->withBatch($batch)
+            ->create([
+                'status' => StatusEnum::PICKEDUP->value,
+            ]);
+
+        Download::factory()
+            ->forAssignment($downloadedAssignment)
+            ->at(Carbon::parse('2030-04-05 15:30:00'))
+            ->create();
+
+        Livewire::test(AssignmentsRelationManager::class, [
+            'ownerRecord' => $video,
+            'pageClass' => ViewVideo::class,
+        ])
+            ->assertSuccessful()
+            ->assertCanSeeTableRecords([
+                $pendingAssignment,
+                $rejectedAssignment,
+                $downloadedAssignment,
+            ])
+            ->assertTableColumnStateSet('download_state', 'Noch nicht heruntergeladen', record: $pendingAssignment)
+            ->assertTableColumnStateSet('download_state', 'Zurückgegeben', record: $rejectedAssignment)
+            ->assertTableColumnStateSet('download_state', 'Heruntergeladen am 05.04.2030 15:30', record: $downloadedAssignment);
+    }
+
+    private function grantVideoPermissions(): void
+    {
+        $permissions = [
+            'ViewAny:Video',
+            'View:Video',
+        ];
+
+        foreach ($permissions as $permission) {
+            Permission::findOrCreate($permission, GuardEnum::STANDARD->value);
+        }
+
+        $this->user->givePermissionTo($permissions);
+    }
+}

--- a/tests/Integration/Filament/Standard/Resources/VideoResource/Widgets/VideoStatsOverviewTest.php
+++ b/tests/Integration/Filament/Standard/Resources/VideoResource/Widgets/VideoStatsOverviewTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Filament\Standard\Resources\VideoResource\Widgets;
+
+use App\Enum\Guard\GuardEnum;
+use App\Enum\PanelEnum;
+use App\Filament\Standard\Resources\VideoResource\Widgets\VideoStatsOverview;
+use App\Models\Team;
+use App\Models\User;
+use App\Repository\AssignmentRepository;
+use App\Repository\TeamRepository;
+use App\Repository\VideoRepository;
+use App\Services\VideoStatsService;
+use Filament\Facades\Filament;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+use Mockery;
+use Tests\DatabaseTestCase;
+
+final class VideoStatsOverviewTest extends DatabaseTestCase
+{
+    private User $user;
+
+    private Team $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()
+            ->withOwnTeam()
+            ->admin(GuardEnum::STANDARD)
+            ->create();
+
+        $this->tenant = app(TeamRepository::class)->getDefaultTeamForUser($this->user);
+
+        Filament::setCurrentPanel(PanelEnum::STANDARD->value);
+        Filament::setTenant($this->tenant, true);
+        Filament::auth()->login($this->user);
+        $this->actingAs($this->user, GuardEnum::STANDARD->value);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+
+        parent::tearDown();
+    }
+
+    public function testGetStatsUsesVideoStatsServiceForAuthenticatedUser(): void
+    {
+        $videoRepository = Mockery::mock(VideoRepository::class);
+        $assignmentRepository = Mockery::mock(AssignmentRepository::class);
+
+        $videoRepository->shouldReceive('getVideoCountForUser')
+            ->once()
+            ->with($this->user)
+            ->andReturn(10);
+
+        $assignmentRepository->shouldReceive('getPickedUpOffersCountForUser')
+            ->once()
+            ->with($this->user)
+            ->andReturn(5);
+
+        $assignmentRepository->shouldReceive('getAvailableOffersCountForUser')
+            ->once()
+            ->with($this->user)
+            ->andReturn(3);
+
+        $assignmentRepository->shouldReceive('getExpiredOffersCountForUser')
+            ->once()
+            ->with($this->user)
+            ->andReturn(1);
+
+        $service = new VideoStatsService($videoRepository, $assignmentRepository);
+
+        $this->app->instance(VideoStatsService::class, $service);
+
+        $widget = app(VideoStatsOverview::class);
+
+        $reflection = new \ReflectionClass($widget);
+        $method = $reflection->getMethod('getStats');
+        $method->setAccessible(true);
+
+        $stats = $method->invoke($widget);
+
+        $this->assertCount(4, $stats);
+
+        $this->assertSame('Videos', $stats[0]->getLabel());
+        $this->assertSame('10', $stats[0]->getValue());
+
+        $this->assertSame('Heruntergeladene Videos', $stats[1]->getLabel());
+        $this->assertSame('5', $stats[1]->getValue());
+
+        $this->assertSame('Verfügbare Offers', $stats[2]->getLabel());
+        $this->assertSame('3', $stats[2]->getValue());
+
+        $this->assertSame('Abgelaufene Offers', $stats[3]->getLabel());
+        $this->assertSame('1', $stats[3]->getValue());
+    }
+}


### PR DESCRIPTION
## Summary
- add integration coverage for the standard VideoResource assignments relation manager
- verify the standard VideoResource stats widget pulls metrics from the stats service for the authenticated user

## Testing
- ./vendor/bin/phpunit --testsuite Integration --no-coverage --filter AssignmentsRelationManagerTest
- ./vendor/bin/phpunit --testsuite Integration --no-coverage --filter VideoStatsOverviewTest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b71c942588329bedc6d82ed8ea10a)