### PR TITLE
Add coverage for Filament config mapper and team resource pages

### DIFF
--- a/tests/Feature/Filament/Resources/TeamResourceTest.php
+++ b/tests/Feature/Filament/Resources/TeamResourceTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament\Resources;
+
+use App\Filament\Resources\TeamResource\Pages\CreateTeam;
+use App\Filament\Resources\TeamResource\Pages\EditTeam;
+use App\Filament\Resources\TeamResource\Pages\ListTeams;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+use Tests\DatabaseTestCase;
+
+final class TeamResourceTest extends DatabaseTestCase
+{
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->admin()->create();
+        $this->actingAs($this->admin);
+    }
+
+    public function testRegularUserCannotAccessTeamList(): void
+    {
+        $user = User::factory()->standard()->create();
+        $this->actingAs($user);
+
+        Livewire::test(ListTeams::class)
+            ->assertStatus(403);
+    }
+
+    public function testListTeamsDisplaysCreatedRecords(): void
+    {
+        $owner = User::factory()->create(['name' => 'Owner User']);
+        $team = Team::factory()
+            ->forUser($owner)
+            ->create(['name' => 'Filament Team']);
+
+        Livewire::test(ListTeams::class)
+            ->assertStatus(200)
+            ->assertCanSeeTableRecords([$team])
+            ->assertTableColumnStateSet('name', $team->name, record: $team)
+            ->assertTableColumnStateSet('owner.name', $owner->name, record: $team)
+            ->assertTableColumnExists('created_at', record: $team)
+            ->assertTableColumnExists('updated_at', record: $team);
+    }
+
+    public function testCreateTeamFormStoresTeam(): void
+    {
+        $owner = User::factory()->create();
+        $slug = 'team-'.Str::random(6);
+
+        Livewire::test(CreateTeam::class)
+            ->assertStatus(200)
+            ->fillForm([
+                'slug' => $slug,
+                'name' => 'Marketing',
+                'owner_id' => $owner->getKey(),
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        $this->assertDatabaseHas(Team::class, [
+            'slug' => $slug,
+            'name' => 'Marketing',
+            'owner_id' => $owner->getKey(),
+        ]);
+    }
+
+    public function testEditTeamFormUpdatesTeam(): void
+    {
+        $owner = User::factory()->create(['name' => 'Original Owner']);
+        $newOwner = User::factory()->create(['name' => 'New Owner']);
+        $team = Team::factory()
+            ->forUser($owner)
+            ->create([
+                'name' => 'Old Name',
+                'slug' => 'old-slug',
+            ]);
+
+        Livewire::test(EditTeam::class, ['record' => $team->getKey()])
+            ->assertStatus(200)
+            ->assertFormSet([
+                'name' => 'Old Name',
+                'slug' => 'old-slug',
+                'owner_id' => $owner->getKey(),
+            ])
+            ->fillForm([
+                'name' => 'Updated Name',
+                'slug' => 'updated-slug',
+                'owner_id' => $newOwner->getKey(),
+            ])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $team->refresh();
+
+        $this->assertSame('Updated Name', $team->name);
+        $this->assertSame('updated-slug', $team->slug);
+        $this->assertSame($newOwner->getKey(), $team->owner_id);
+    }
+}

--- a/tests/Integration/Filament/Support/ConfigFilamentMapperTest.php
+++ b/tests/Integration/Filament/Support/ConfigFilamentMapperTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Filament\Support;
+
+use App\Enum\ConfigTypeEnum;
+use App\Filament\Support\ConfigFilamentMapper;
+use Filament\Forms\Components\KeyValue;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Tests\TestCase;
+
+final class ConfigFilamentMapperTest extends TestCase
+{
+    public function testSelectableOptionsRenderAsSingleSelect(): void
+    {
+        $components = ConfigFilamentMapper::valueFormComponents(ConfigTypeEnum::STRING->value, ['one', 'two']);
+
+        $this->assertCount(1, $components);
+
+        $select = $components[0];
+
+        $this->assertInstanceOf(Select::class, $select);
+        $this->assertSame('value', $select->getName());
+        $this->assertSame(['one' => 'one', 'two' => 'two'], $select->getOptions());
+        $this->assertSame('Value', $select->getLabel());
+        $this->assertTrue($select->isRequired());
+        $this->assertFalse($select->isMultiple());
+    }
+
+    public function testJsonSelectAllowsMultipleValues(): void
+    {
+        $components = ConfigFilamentMapper::valueFormComponents(ConfigTypeEnum::JSON->value, ['alpha']);
+
+        $this->assertCount(1, $components);
+
+        $select = $components[0];
+
+        $this->assertInstanceOf(Select::class, $select);
+        $this->assertTrue($select->isMultiple());
+    }
+
+    public function testBooleanTypeMapsToRequiredToggle(): void
+    {
+        $components = ConfigFilamentMapper::valueFormComponents(ConfigTypeEnum::BOOL->value);
+
+        $this->assertCount(1, $components);
+
+        $toggle = $components[0];
+
+        $this->assertInstanceOf(Toggle::class, $toggle);
+        $this->assertSame('value', $toggle->getName());
+        $this->assertSame('Value', $toggle->getLabel());
+        $this->assertTrue($toggle->isRequired());
+    }
+
+    public function testNumericTypesReturnNumericTextInput(): void
+    {
+        foreach ([ConfigTypeEnum::INT, ConfigTypeEnum::FLOAT] as $type) {
+            $components = ConfigFilamentMapper::valueFormComponents($type->value);
+
+            $this->assertCount(1, $components);
+
+            $textInput = $components[0];
+
+            $this->assertInstanceOf(TextInput::class, $textInput);
+            $this->assertSame('value', $textInput->getName());
+            $this->assertSame('Value', $textInput->getLabel());
+            $this->assertTrue($textInput->isRequired());
+            $this->assertTrue($textInput->isNumeric());
+        }
+    }
+
+    public function testJsonTypeReturnsRequiredKeyValueField(): void
+    {
+        $components = ConfigFilamentMapper::valueFormComponents(ConfigTypeEnum::JSON->value);
+
+        $this->assertCount(1, $components);
+
+        $keyValue = $components[0];
+
+        $this->assertInstanceOf(KeyValue::class, $keyValue);
+        $this->assertSame('value', $keyValue->getName());
+        $this->assertSame('Value', $keyValue->getLabel());
+        $this->assertTrue($keyValue->isRequired());
+    }
+
+    public function testStringTypeReturnsFullWidthTextarea(): void
+    {
+        $components = ConfigFilamentMapper::valueFormComponents(null);
+
+        $this->assertCount(1, $components);
+
+        $textarea = $components[0];
+
+        $this->assertInstanceOf(Textarea::class, $textarea);
+        $this->assertSame('value', $textarea->getName());
+        $this->assertSame('Value', $textarea->getLabel());
+        $this->assertTrue($textarea->isRequired());
+        $this->assertSame('full', $textarea->getColumnSpan()['default']);
+    }
+
+    public function testTypeLabelUsesNormalizedCastType(): void
+    {
+        $this->assertSame('Json', ConfigFilamentMapper::typeLabel('ARRAY'));
+        $this->assertSame('String', ConfigFilamentMapper::typeLabel(null));
+    }
+}


### PR DESCRIPTION
## Summary
- add integration tests for the Filament ConfigFilamentMapper component mappings
- add feature coverage for TeamResource list, create, and edit pages

## Testing
- ./vendor/bin/phpunit --testsuite Integration --filter ConfigFilamentMapperTest --no-coverage
- ./vendor/bin/phpunit --testsuite Feature --filter TeamResourceTest --no-coverage

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bbfac98608329812e05e0a50ebdcf)