### PR TITLE
Add integration tests for model observers

### DIFF
--- a/tests/Integration/Observers/BaseObserverTest.php
+++ b/tests/Integration/Observers/BaseObserverTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Observers;
+
+use App\Models\User;
+use App\Observers\BaseObserver;
+use Tests\DatabaseTestCase;
+
+final class BaseObserverTest extends DatabaseTestCase
+{
+    public function testBaseObserverHooksDoNotMutateModel(): void
+    {
+        $model = User::factory()->make([
+            'name' => 'Observer Base User',
+            'email' => 'base@example.com',
+        ]);
+
+        $originalAttributes = $model->getAttributes();
+
+        $observer = new class extends BaseObserver {
+        };
+
+        $observer->retrieved($model);
+        $observer->creating($model);
+        $observer->created($model);
+        $observer->updating($model);
+        $observer->updated($model);
+        $observer->saving($model);
+        $observer->saved($model);
+        $observer->restoring($model);
+        $observer->restored($model);
+        $observer->forceDeleting($model);
+        $observer->forceDeleted($model);
+        $observer->replicating($model);
+
+        $deletingResult = $observer->deleting($model);
+        $observer->deleted($model);
+
+        $this->assertSame($originalAttributes, $model->getAttributes());
+        $this->assertNull($deletingResult);
+    }
+}

--- a/tests/Integration/Observers/TeamObserverTest.php
+++ b/tests/Integration/Observers/TeamObserverTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Observers;
+
+use App\Models\Team;
+use Illuminate\Support\Str;
+use Tests\DatabaseTestCase;
+
+final class TeamObserverTest extends DatabaseTestCase
+{
+    public function testAssignsUuidSlugWhenMissing(): void
+    {
+        $team = Team::factory()->create([
+            'slug' => null,
+        ]);
+
+        $this->assertNotEmpty($team->slug);
+        $this->assertTrue(Str::isUuid((string)$team->slug));
+    }
+
+    public function testKeepsExistingSlugUntouched(): void
+    {
+        $team = Team::factory()->create([
+            'slug' => 'custom-slug',
+        ]);
+
+        $this->assertSame('custom-slug', $team->slug);
+    }
+}

--- a/tests/Integration/Observers/UserObserverTest.php
+++ b/tests/Integration/Observers/UserObserverTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Observers;
+
+use App\Enum\Guard\GuardEnum;
+use App\Enum\Users\RoleEnum;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\DatabaseTestCase;
+
+final class UserObserverTest extends DatabaseTestCase
+{
+    public function testCreatedUserGetsDefaultRoleAndOwnTeam(): void
+    {
+        Role::query()->firstOrCreate([
+            'name' => RoleEnum::REGULAR->value,
+            'guard_name' => GuardEnum::DEFAULT->value,
+        ]);
+
+        $user = User::factory()->create([
+            'name' => 'Observer User',
+            'email' => 'observer@example.com',
+        ]);
+
+        $this->assertTrue(
+            $user->hasRole(RoleEnum::REGULAR->value, GuardEnum::DEFAULT->value)
+        );
+
+        $ownedTeam = Team::query()->where('owner_id', $user->getKey())->first();
+        $this->assertNotNull($ownedTeam);
+        $this->assertTrue($user->teams->contains($ownedTeam));
+    }
+
+    public function testAddsDefaultRoleAlongsideExistingRoles(): void
+    {
+        $defaultRole = Role::query()->firstOrCreate([
+            'name' => RoleEnum::REGULAR->value,
+            'guard_name' => GuardEnum::DEFAULT->value,
+        ]);
+
+        $existingRole = Role::query()->firstOrCreate([
+            'name' => 'existing-role',
+            'guard_name' => GuardEnum::DEFAULT->value,
+        ]);
+
+        $user = User::withoutEvents(fn() => User::factory()->create([
+            'name' => 'Observer User Roles',
+        ]));
+
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+        $user->assignRole($existingRole);
+
+        $this->assertDatabaseHas('model_has_roles', [
+            'role_id' => $existingRole->getKey(),
+            'model_id' => $user->getKey(),
+            'model_type' => User::class,
+        ]);
+
+        $observer = app()->make(\App\Observers\UserObserver::class);
+        $observer->created($user);
+
+        $freshUser = $user->fresh();
+
+        $this->assertTrue($freshUser->hasRole($defaultRole->name, GuardEnum::DEFAULT->value));
+        $this->assertTrue($freshUser->hasRole($existingRole->name, GuardEnum::DEFAULT->value));
+    }
+}

--- a/tests/Integration/Observers/VideoObserverTest.php
+++ b/tests/Integration/Observers/VideoObserverTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Observers;
+
+use App\Facades\PathBuilder;
+use App\Models\Video;
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Storage;
+use Mockery;
+use Tests\DatabaseTestCase;
+
+final class VideoObserverTest extends DatabaseTestCase
+{
+    public function testDeletingRemovesVideoAndPreviewFiles(): void
+    {
+        Storage::fake('local');
+        Storage::fake('public');
+
+        $hash = '0c8f4a3bce2b4a5a92c8845b0fb40f2c0f8fa4c5a0d4880f17c5b5e3a1e7b6d3';
+        $videoPath = 'videos/sample.mp4';
+        $previewPath = PathBuilder::forPreviewByHash($hash);
+
+        Storage::disk('local')->put($videoPath, 'video-content');
+        Storage::disk('local')->put($previewPath, 'preview-content');
+        Storage::disk('public')->put($previewPath, 'preview-content');
+
+        $video = Video::factory()->create([
+            'hash' => $hash,
+            'path' => $videoPath,
+            'disk' => 'local',
+        ]);
+
+        $this->assertTrue($video->delete());
+
+        Storage::disk('local')->assertMissing($videoPath);
+        Storage::disk('public')->assertMissing($previewPath);
+    }
+
+    public function testDeletingStopsWhenPrimaryFileDeletionFails(): void
+    {
+        $hash = 'd2b4c9f1e3a54b6c8d9e0fa1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1';
+        $videoPath = 'videos/failing.mp4';
+        $previewPath = PathBuilder::forPreviewByHash($hash);
+
+        $storageDisk = Mockery::mock(Filesystem::class);
+        $storageDisk->shouldReceive('exists')->with($videoPath)->andReturn(true);
+        $storageDisk->shouldReceive('delete')->with($videoPath)->andReturn(false);
+        $storageDisk->shouldReceive('exists')->with($previewPath)->andReturn(false);
+
+        $previewDisk = Mockery::mock(Filesystem::class);
+        $previewDisk->shouldReceive('exists')->with($previewPath)->andReturn(false);
+
+        Storage::shouldReceive('disk')->with('fail-disk')->andReturn($storageDisk);
+        Storage::shouldReceive('disk')->with('public')->andReturn($previewDisk);
+
+        $video = Video::factory()->create([
+            'hash' => $hash,
+            'path' => $videoPath,
+            'disk' => 'fail-disk',
+        ]);
+
+        $this->assertFalse($video->delete());
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
## Summary
- add integration coverage for the base observer lifecycle hooks
- verify team slug generation, user observer side effects, and video deletion handling
- ensure existing roles are preserved while the default role is applied

## Testing
- ./vendor/bin/phpunit --testsuite=Integration --no-coverage --filter "Observers"


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bcc858d2483298c57a98559155b98)