### PR TITLE
Add integration coverage for application models

### DIFF
--- a/tests/Integration/Models/ActivityTest.php
+++ b/tests/Integration/Models/ActivityTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Models;
+
+use App\Models\Activity;
+use App\Models\Video;
+use Tests\DatabaseTestCase;
+
+final class ActivityTest extends DatabaseTestCase
+{
+    public function testLogsActivityWithApplicationModel(): void
+    {
+        $video = Video::factory()->create();
+
+        config(['activitylog.activity_model' => Activity::class]);
+
+        $activity = activity()
+            ->performedOn($video)
+            ->withProperties(['foo' => 'bar'])
+            ->log('test');
+
+        $this->assertInstanceOf(Activity::class, $activity);
+        $this->assertSame('test', $activity->description);
+        $this->assertSame($video->getKey(), $activity->subject_id);
+        $this->assertSame(Video::class, $activity->subject_type);
+        $this->assertSame(['foo' => 'bar'], $activity->properties->toArray());
+    }
+}

--- a/tests/Integration/Models/AssignmentTest.php
+++ b/tests/Integration/Models/AssignmentTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Models;
+
+use App\Enum\StatusEnum;
+use App\Models\Assignment;
+use App\Models\Batch;
+use App\Models\Channel;
+use App\Models\Download;
+use App\Models\Notification;
+use App\Models\User;
+use App\Models\Video;
+use Tests\DatabaseTestCase;
+
+final class AssignmentTest extends DatabaseTestCase
+{
+    public function testBelongsToVideoChannelBatchAndHasDownloads(): void
+    {
+        $batch = Batch::factory()->create();
+        $video = Video::factory()->create();
+        $channel = Channel::factory()->create();
+
+        $assignment = Assignment::factory()
+            ->forVideo($video)
+            ->forChannel($channel)
+            ->withBatch($batch)
+            ->has(Download::factory()->count(2))
+            ->create();
+
+        $this->assertTrue($assignment->video->is($video));
+        $this->assertTrue($assignment->channel->is($channel));
+        $this->assertTrue($assignment->batch->is($batch));
+        $this->assertCount(2, $assignment->downloads);
+    }
+
+    public function testHasUsersClipsScopeReturnsAssignments(): void
+    {
+        $user = User::factory()->create();
+        $videoWithClip = Video::factory()->create();
+        $videoWithoutClip = Video::factory()->create();
+        $batch = Batch::factory()->create();
+
+        $clip = $videoWithClip->clips()->create([
+            'start_sec' => 0,
+            'end_sec' => 10,
+        ]);
+        $clip->setUser($user)->save();
+
+        $assignmentWithClip = Assignment::factory()->forVideo($videoWithClip)->withBatch($batch)->create();
+        Assignment::factory()->forVideo($videoWithoutClip)->withBatch($batch)->create();
+
+        $found = Assignment::query()->hasUsersClips($user)->get();
+
+        $this->assertCount(1, $found);
+        $this->assertTrue($found->first()->is($assignmentWithClip));
+    }
+
+    public function testSetExpiresAtAndSetNotifiedMutateAttributes(): void
+    {
+        $assignment = Assignment::factory()->create([
+            'expires_at' => null,
+            'status' => StatusEnum::QUEUED->value,
+            'last_notified_at' => null,
+            'batch_id' => Batch::factory()->create(),
+        ]);
+
+        $assignment->setExpiresAt(2);
+        $this->assertNotNull($assignment->expires_at);
+        $this->assertTrue($assignment->expires_at->greaterThan(now()->addHours(23)));
+
+        $assignment->setNotified();
+
+        $this->assertSame(StatusEnum::NOTIFIED->value, $assignment->status);
+        $this->assertNotNull($assignment->last_notified_at);
+    }
+
+    public function testBelongsToNotification(): void
+    {
+        $notification = Notification::factory()->create();
+
+        $assignment = Assignment::factory()
+            ->state(['notification_id' => $notification->getKey()])
+            ->withBatch()
+            ->create();
+
+        $this->assertTrue($assignment->notification->is($notification));
+    }
+}

--- a/tests/Integration/Models/BatchTest.php
+++ b/tests/Integration/Models/BatchTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Models;
+
+use App\Models\Assignment;
+use App\Models\Batch;
+use App\Models\Channel;
+use App\Models\Clip;
+use App\Models\Video;
+use Tests\DatabaseTestCase;
+
+final class BatchTest extends DatabaseTestCase
+{
+    public function testHasAssignmentsClipsAndChannels(): void
+    {
+        $batch = Batch::factory()->create();
+        $video = Video::factory()->create();
+        $channel = Channel::factory()->create();
+
+        $assignment = Assignment::factory()
+            ->forVideo($video)
+            ->forChannel($channel)
+            ->withBatch($batch)
+            ->create();
+
+        Clip::factory()->create([
+            'video_id' => $assignment->video_id,
+        ]);
+
+        $batch->refresh();
+
+        $this->assertCount(1, $batch->assignments);
+        $this->assertTrue($batch->assignments->first()->is($assignment));
+        $this->assertCount(1, $batch->clips);
+        $this->assertCount(1, $batch->channels);
+        $this->assertTrue($batch->channels->first()->is($channel));
+    }
+}

--- a/tests/Integration/Models/ChannelTest.php
+++ b/tests/Integration/Models/ChannelTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Models;
+
+use App\Models\Assignment;
+use App\Models\Channel;
+use App\Models\ChannelVideoBlock;
+use App\Models\Video;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Facades\Schema;
+use Tests\DatabaseTestCase;
+
+final class ChannelTest extends DatabaseTestCase
+{
+    public function testScopesAndRelationships(): void
+    {
+        $activeChannel = Channel::factory()->create([
+            'is_video_reception_paused' => false,
+        ]);
+        $pausedChannel = Channel::factory()->create([
+            'is_video_reception_paused' => true,
+        ]);
+
+        Assignment::factory()->forChannel($activeChannel)->withBatch()->create();
+        $block = ChannelVideoBlock::factory()->forChannel($activeChannel)->create();
+
+        $activeBlocks = $activeChannel->activeVideoBlocks;
+
+        $this->assertTrue(Channel::query()->isActive()->get()->contains($activeChannel));
+        $this->assertTrue($activeChannel->assignments->first()->channel->is($activeChannel));
+        $this->assertCount(1, $activeChannel->videoBlocks);
+        $this->assertTrue($activeBlocks->first()->is($block));
+        $this->assertTrue($activeChannel->blockedVideos->first()->is($block->video));
+        $this->assertTrue($activeBlocks->every(fn(ChannelVideoBlock $b) => $b->until->greaterThan(now())));
+        $this->assertTrue($pausedChannel->is_video_reception_paused);
+    }
+
+    public function testApprovalHelpersReturnSignedData(): void
+    {
+        $channel = Channel::factory()->create([
+            'email' => 'creator@example.com',
+        ]);
+
+        $expectedToken = sha1($channel->email.config('app.key'));
+
+        $this->assertSame($expectedToken, $channel->getApprovalToken());
+
+        $approvalUrl = $channel->getApprovalUrl();
+        $this->assertTrue(str_contains($approvalUrl, (string) $channel->getKey()));
+        $this->assertTrue(str_contains($approvalUrl, $expectedToken));
+        $this->assertSame(URL::route('channels.approve', ['channel' => $channel, 'token' => $expectedToken]), $approvalUrl);
+    }
+
+    public function testAssignedTeamsRelationship(): void
+    {
+        if (! Schema::hasTable('channel_user')) {
+            Schema::create('channel_user', static function (Blueprint $table): void {
+                $table->id();
+                $table->foreignId('channel_id')->constrained()->cascadeOnDelete();
+                $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+                $table->timestamps();
+            });
+        }
+
+        $channel = Channel::factory()->create();
+        $user = \App\Models\User::factory()->create();
+
+        $channel->assignedTeams()->attach($user->getKey());
+
+        $this->assertTrue($channel->assignedTeams->first()->is($user));
+    }
+}

--- a/tests/Integration/Models/ChannelVideoBlockTest.php
+++ b/tests/Integration/Models/ChannelVideoBlockTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Models;
+
+use App\Models\Channel;
+use App\Models\ChannelVideoBlock;
+use App\Models\Video;
+use Tests\DatabaseTestCase;
+
+final class ChannelVideoBlockTest extends DatabaseTestCase
+{
+    public function testBelongsToChannelAndVideo(): void
+    {
+        $channel = Channel::factory()->create();
+        $video = Video::factory()->create();
+
+        $block = ChannelVideoBlock::factory()
+            ->forChannel($channel)
+            ->forVideo($video)
+            ->create();
+
+        $this->assertTrue($block->channel->is($channel));
+        $this->assertTrue($block->video->is($video));
+    }
+
+    public function testActiveScopeReturnsNonExpiredBlocks(): void
+    {
+        $activeBlock = ChannelVideoBlock::factory()->create();
+        ChannelVideoBlock::factory()->expired()->create();
+
+        $found = ChannelVideoBlock::query()->active()->get();
+
+        $this->assertCount(1, $found);
+        $this->assertTrue($found->first()->is($activeBlock));
+    }
+}

--- a/tests/Integration/Models/ClipTest.php
+++ b/tests/Integration/Models/ClipTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Models;
+
+use App\Models\Clip;
+use App\Models\User;
+use App\Models\Video;
+use Tests\DatabaseTestCase;
+
+final class ClipTest extends DatabaseTestCase
+{
+    public function testBelongsToVideoAndUser(): void
+    {
+        $user = User::factory()->create();
+        $video = Video::factory()->create();
+
+        $clip = Clip::factory()->create([
+            'video_id' => $video->getKey(),
+        ]);
+
+        $clip->setUser($user)->save();
+
+        $this->assertTrue($clip->video->is($video));
+        $this->assertTrue($clip->user->is($user));
+        $this->assertSame($user->display_name, $clip->submitted_by);
+    }
+
+    public function testAccessorsExposeTimesAndDuration(): void
+    {
+        $clip = Clip::factory()->create([
+            'start_sec' => 30,
+            'end_sec' => 75,
+        ]);
+
+        $this->assertSame('00:30', $clip->start_time);
+        $this->assertSame('01:15', $clip->end_time);
+        $this->assertSame(45, $clip->duration);
+    }
+
+    public function testGeneratesPreviewPathFromVideoAndTimestamps(): void
+    {
+        $clip = Clip::factory()->create([
+            'start_sec' => 5,
+            'end_sec' => 10,
+        ]);
+
+        $clip->load('video');
+
+        $hash = md5($clip->video->getKey().'_'.$clip->start_sec.'_'.$clip->end_sec);
+        $expected = "previews/{$hash}.mp4";
+
+        $this->assertSame($expected, $clip->getPreviewPath());
+    }
+}

--- a/tests/Integration/Models/ConfigTest.php
+++ b/tests/Integration/Models/ConfigTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Models;
+
+use App\Models\Config;
+use App\Models\Config\Category;
+use Tests\DatabaseTestCase;
+
+final class ConfigTest extends DatabaseTestCase
+{
+    public function testBelongsToCategory(): void
+    {
+        $category = Category::query()->create([
+            'slug' => 'general',
+            'name' => 'General',
+            'is_visible' => true,
+        ]);
+
+        $config = Config::query()->create([
+            'config_category_id' => $category->getKey(),
+            'key' => 'feature.flags',
+            'cast_type' => 'array',
+            'value' => json_encode(['enabled' => true]),
+            'selectable' => [],
+            'is_visible' => true,
+        ]);
+
+        $this->assertTrue($config->category->is($category));
+        $this->assertTrue($category->configs->contains($config));
+    }
+
+    public function testValueCastingAndValidation(): void
+    {
+        $config = Config::query()->create([
+            'key' => 'feature.flags',
+            'cast_type' => 'array',
+            'value' => json_encode(['enabled' => true]),
+            'selectable' => [],
+            'is_visible' => true,
+        ]);
+
+        $this->assertIsArray($config->value);
+        $this->assertTrue($config->value['enabled']);
+
+        $config->value = 'hello world';
+        $config->cast_type = 'string';
+        $config->save();
+
+        $this->assertSame('hello world', $config->fresh()->value);
+    }
+}

--- a/tests/Integration/Models/DownloadTest.php
+++ b/tests/Integration/Models/DownloadTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Models;
+
+use App\Models\Assignment;
+use App\Models\Download;
+use Tests\DatabaseTestCase;
+
+final class DownloadTest extends DatabaseTestCase
+{
+    public function testBelongsToAssignment(): void
+    {
+        $assignment = Assignment::factory()->withBatch()->create();
+
+        $download = Download::factory()->create([
+            'assignment_id' => $assignment->getKey(),
+        ]);
+
+        $this->assertTrue($download->assignment->is($assignment));
+    }
+}

--- a/tests/Integration/Models/MailLogTest.php
+++ b/tests/Integration/Models/MailLogTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Models;
+
+use App\Enum\MailDirection;
+use App\Enum\MailStatus;
+use App\Models\MailLog;
+use Tests\DatabaseTestCase;
+
+final class MailLogTest extends DatabaseTestCase
+{
+    public function testCastsEnumerationsAndMeta(): void
+    {
+        $log = MailLog::factory()->create([
+            'direction' => MailDirection::INBOUND,
+            'status' => MailStatus::Sent,
+            'meta' => ['attempts' => 1],
+        ]);
+
+        $this->assertInstanceOf(MailDirection::class, $log->direction);
+        $this->assertInstanceOf(MailStatus::class, $log->status);
+        $this->assertSame(['attempts' => 1], $log->meta);
+    }
+}

--- a/tests/Integration/Models/ModelHasRoleTeamTest.php
+++ b/tests/Integration/Models/ModelHasRoleTeamTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Models;
+
+use App\Models\Pivots\ModelHasRoleTeam;
+use App\Models\Role;
+use App\Models\User;
+use Tests\DatabaseTestCase;
+
+final class ModelHasRoleTeamTest extends DatabaseTestCase
+{
+    public function testStoresPivotWithTeamContext(): void
+    {
+        $user = User::factory()->create();
+        $role = Role::factory()->create();
+
+        $pivot = new ModelHasRoleTeam([
+            'role_id' => $role->getKey(),
+            'model_type' => User::class,
+            'model_id' => $user->getKey(),
+        ]);
+        $pivot->timestamps = false;
+        $pivot->save();
+
+        $this->assertDatabaseHas('model_has_roles', [
+            'role_id' => $role->getKey(),
+            'model_id' => $user->getKey(),
+        ]);
+        $this->assertSame($role->getKey(), $pivot->role_id);
+        $this->assertSame($user->getKey(), $pivot->model_id);
+    }
+}

--- a/tests/Integration/Models/NotificationTest.php
+++ b/tests/Integration/Models/NotificationTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Models;
+
+use App\Models\Assignment;
+use App\Models\Channel;
+use App\Models\Notification;
+use Tests\DatabaseTestCase;
+
+final class NotificationTest extends DatabaseTestCase
+{
+    public function testBelongsToChannelAndHasAssignments(): void
+    {
+        $channel = Channel::factory()->create();
+
+        $notification = Notification::factory()
+            ->state(['channel_id' => $channel->getKey()])
+            ->has(Assignment::factory()->withBatch()->count(2))
+            ->create();
+
+        $this->assertTrue($notification->channel->is($channel));
+        $this->assertCount(2, $notification->assignments);
+    }
+}

--- a/tests/Integration/Models/OfferLinkClickTest.php
+++ b/tests/Integration/Models/OfferLinkClickTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Models;
+
+use App\Models\Batch;
+use App\Models\Channel;
+use App\Models\OfferLinkClick;
+use App\Models\User;
+use Tests\DatabaseTestCase;
+
+final class OfferLinkClickTest extends DatabaseTestCase
+{
+    public function testBelongsToBatchChannelAndUser(): void
+    {
+        $batch = Batch::factory()->create();
+        $channel = Channel::factory()->create();
+        $user = User::factory()->create();
+
+        $click = OfferLinkClick::factory()->create([
+            'batch_id' => $batch->getKey(),
+            'channel_id' => $channel->getKey(),
+            'user_id' => $user->getKey(),
+            'clicked_at' => now(),
+        ]);
+
+        $this->assertTrue($click->batch->is($batch));
+        $this->assertTrue($click->channel->is($channel));
+        $this->assertTrue($click->user->is($user));
+    }
+}

--- a/tests/Integration/Models/PageTest.php
+++ b/tests/Integration/Models/PageTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Models;
+
+use App\Models\Page;
+use Tests\DatabaseTestCase;
+
+final class PageTest extends DatabaseTestCase
+{
+    public function testCanPersistPage(): void
+    {
+        $page = Page::factory()->create([
+            'slug' => 'about',
+            'title' => 'About Us',
+            'section' => 'info',
+            'content' => 'Sample content.',
+        ]);
+
+        $this->assertDatabaseHas('pages', [
+            'id' => $page->id,
+            'slug' => 'about',
+        ]);
+    }
+}

--- a/tests/Integration/Models/PermissionTest.php
+++ b/tests/Integration/Models/PermissionTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Models;
+
+use App\Models\Permission;
+use Spatie\Permission\Models\Permission as SpatiePermission;
+use Tests\DatabaseTestCase;
+
+final class PermissionTest extends DatabaseTestCase
+{
+    public function testExtendsSpatiePermissionAndPersists(): void
+    {
+        $permission = Permission::create(['name' => 'do something', 'guard_name' => 'web']);
+
+        $this->assertInstanceOf(SpatiePermission::class, $permission);
+        $this->assertDatabaseHas('permissions', [
+            'id' => $permission->id,
+            'name' => 'do something',
+        ]);
+    }
+}

--- a/tests/Integration/Models/RoleTest.php
+++ b/tests/Integration/Models/RoleTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Models;
+
+use App\Models\Role;
+use App\Models\Team;
+use App\Models\User;
+use Tests\DatabaseTestCase;
+
+final class RoleTest extends DatabaseTestCase
+{
+    public function testBelongsToManyTeamsViaPivot(): void
+    {
+        $role = Role::factory()->create();
+        $user = User::factory()->create();
+        $team = Team::factory()->forUser($user)->create();
+
+        $role->teams()->attach($team->getKey(), ['user_id' => $user->getKey()]);
+
+        $attachedTeam = $role->teams()->first();
+
+        $this->assertTrue($attachedTeam->is($team));
+        $this->assertDatabaseHas('team_user', [
+            'role_id' => $role->getKey(),
+            'team_id' => $team->getKey(),
+            'user_id' => $user->getKey(),
+        ]);
+    }
+}

--- a/tests/Integration/Models/TeamTest.php
+++ b/tests/Integration/Models/TeamTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Models;
+
+use App\Models\Channel;
+use App\Models\Team;
+use App\Models\User;
+use Tests\DatabaseTestCase;
+
+final class TeamTest extends DatabaseTestCase
+{
+    public function testRelationshipsAndScopes(): void
+    {
+        $owner = User::factory()->create();
+        $team = Team::factory()->forUser($owner)->create();
+        $member = User::factory()->create();
+
+        $team->users()->attach($member->getKey());
+
+        $activeChannel = Channel::factory()->create();
+        $pausedChannel = Channel::factory()->paused()->create();
+
+        $team->assignedChannels()->attach($activeChannel->getKey(), ['quota' => 3]);
+        $team->assignedChannels()->attach($pausedChannel->getKey(), ['quota' => 3]);
+
+        $team->refresh();
+
+        $this->assertTrue($team->owner->is($owner));
+        $this->assertTrue($team->users->contains($member));
+        $this->assertCount(1, $team->assignedChannels);
+        $this->assertTrue($team->assignedChannels->first()->is($activeChannel));
+
+        $ownTeams = Team::query()->isOwnTeam($owner)->get();
+        $this->assertTrue($ownTeams->contains($team));
+    }
+}

--- a/tests/Integration/Models/VideoTest.php
+++ b/tests/Integration/Models/VideoTest.php
@@ -6,6 +6,7 @@ namespace Tests\Integration\Models;
 
 use App\Facades\PathBuilder;
 use App\Models\Clip;
+use App\Models\User;
 use App\Models\Video;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Log;
@@ -84,6 +85,25 @@ final class VideoTest extends DatabaseTestCase
 
         // Assert
         $this->assertNull($result);
+    }
+
+    public function testHasUsersClipsScopeReturnsVideos(): void
+    {
+        $user = User::factory()->create();
+        $videoWithClip = Video::factory()->create();
+        $videoWithoutClip = Video::factory()->create();
+
+        $clip = $videoWithClip->clips()->create([
+            'start_sec' => 0,
+            'end_sec' => 5,
+        ]);
+        $clip->setUser($user)->save();
+
+        $videos = Video::query()->hasUsersClips($user)->get();
+
+        $this->assertCount(1, $videos);
+        $this->assertTrue($videos->first()->is($videoWithClip));
+        $this->assertFalse($videos->contains($videoWithoutClip));
     }
 
     public function testDeletingVideoRemovesFilesFromStorage(): void


### PR DESCRIPTION
## Summary
- add integration tests for all App\Models classes and their relationships
- cover model-specific behaviors such as scopes, casting, and pivot persistence
- extend existing video model tests to include user clip scope

## Testing
- vendor/bin/phpunit --no-coverage tests/Integration/Models


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c4200485c8329beee4b33ea35b0bc)