### PR TITLE
Fix onboarding widget redirect handling

### DIFF
--- a/app/Filament/Standard/Pages/OnboardingWizard.php
+++ b/app/Filament/Standard/Pages/OnboardingWizard.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Filament\Standard\Pages;
+
+use BackedEnum;
+use BezhanSalleh\FilamentShield\Traits\HasPageShield;
+use Filament\Actions\Action;
+use Filament\Facades\Filament;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Pages\Page;
+use Filament\Schemas\Components\Wizard;
+use Filament\Schemas\Schema;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Stringable;
+
+class OnboardingWizard extends Page implements HasForms
+{
+    use HasPageShield;
+    use InteractsWithForms;
+
+    protected static bool $shouldRegisterNavigation = false;
+
+    protected static string|BackedEnum|null $navigationIcon = null;
+
+    protected static ?string $title = 'Onboarding';
+
+    protected string $view = 'filament.standard.pages.onboarding-wizard';
+
+    public ?array $data = [];
+
+    public function mount(): void
+    {
+        $this->form->fill();
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Wizard::make([
+                    Wizard\Step::make('Willkommen')
+                        ->schema([
+                            TextEntry::make('welcome')
+                                ->state($this->markdownFromView('onboarding.steps.welcome'))
+                                ->markdown(),
+                        ]),
+                    Wizard\Step::make('Video-Upload')
+                        ->schema([
+                            TextEntry::make('video-upload')
+                                ->state($this->markdownFromView('onboarding.steps.video-upload'))
+                                ->markdown(),
+                        ]),
+                    Wizard\Step::make('Kanal-Auswahl')
+                        ->schema([
+                            TextEntry::make('channel-selection')
+                                ->state($this->markdownFromView('onboarding.steps.channel-selection'))
+                                ->markdown(),
+                        ]),
+                    Wizard\Step::make('Video-Management')
+                        ->schema([
+                            TextEntry::make('video-management')
+                                ->state($this->markdownFromView('onboarding.steps.video-management'))
+                                ->markdown(),
+                        ]),
+                    Wizard\Step::make('Fertig')
+                        ->schema([
+                            TextEntry::make('done')
+                                ->state($this->markdownFromView('onboarding.steps.finished'))
+                                ->markdown(),
+                        ]),
+                ])->submitAction(
+                    Action::make('submit')
+                        ->label('Onboarding abschließen'),
+                ),
+            ])
+            ->statePath('data');
+    }
+
+    private function markdownFromView(string $view): Stringable
+    {
+        return str(view($view)->render())->trim();
+    }
+
+    public function submit()
+    {
+        $user = Auth::user();
+
+        if ($user) {
+            $user->forceFill(['onboarding_completed' => true])->save();
+        }
+
+        return redirect()->route(
+            'filament.standard.pages.dashboard',
+            ['tenant' => Filament::getTenant()]
+        );
+    }
+}

--- a/app/Filament/Standard/Widgets/OnboardingWizard.php
+++ b/app/Filament/Standard/Widgets/OnboardingWizard.php
@@ -3,92 +3,35 @@
 namespace App\Filament\Standard\Widgets;
 
 use BezhanSalleh\FilamentShield\Traits\HasWidgetShield;
-use Filament\Forms\Concerns\InteractsWithForms;
-use Filament\Forms\Contracts\HasForms;
-use Filament\Infolists\Components\TextEntry;
-use Filament\Notifications\Notification;
-use Filament\Schemas\Components\Wizard;
-use Filament\Schemas\Schema;
+use Filament\Facades\Filament;
 use Filament\Widgets\Widget;
-use Illuminate\Support\Stringable;
+use Illuminate\Support\Facades\Auth;
 
-class OnboardingWizard extends Widget implements HasForms
+class OnboardingWizard extends Widget
 {
-    use InteractsWithForms;
     use HasWidgetShield;
 
-    protected static ?string $modalId = 'onboarding-wizard';
-    protected string $view = 'filament.standard.widgets.onboarding-wizard';
-    protected static bool $isLazy = false;
+    public bool $shouldOpen = false;
 
-    public function mount(): void
-    {
-        if (static::canView()) {
-            $this->dispatch('open-modal', id: static::$modalId);
-        }
-    }
+    protected string $view = 'filament.standard.widgets.onboarding-wizard';
+
+    protected static bool $isLazy = false;
 
     public static function canView(): bool
     {
-        return auth()->user()?->onboarding_completed === false;
+        $user = Auth::user();
+
+        return $user ? $user->onboarding_completed === false : false;
     }
 
-    public function form(Schema $schema): Schema
+    public function mount()
     {
-        return $schema->components([
-            Wizard::make([
+        $user = Auth::user();
 
-                Wizard\Step::make('Willkommen')
-                    ->schema([
-                        TextEntry::make('intro')
-                            ->state($this->markdownFromView('onboarding.steps.welcome'))
-                            ->markdown(),
-                    ]),
-
-                Wizard\Step::make('Video-Upload')
-                    ->schema([
-                        TextEntry::make('video-upload')
-                            ->state($this->markdownFromView('onboarding.steps.video-upload'))
-                            ->markdown(),
-                    ]),
-
-                Wizard\Step::make('Kanal-Auswahl')
-                    ->schema([
-                        TextEntry::make('channel-selection')
-                            ->state($this->markdownFromView('onboarding.steps.channel-selection'))
-                            ->markdown(),
-                    ]),
-
-                Wizard\Step::make('Video-Management')
-                    ->schema([
-                        TextEntry::make('video-management')
-                            ->state($this->markdownFromView('onboarding.steps.video-management'))
-                            ->markdown(),
-                    ]),
-
-                Wizard\Step::make('Fertig')
-                    ->schema([
-                        TextEntry::make('done')
-                            ->state($this->markdownFromView('onboarding.steps.finished'))
-                            ->markdown(),
-                    ]),
-
-            ]),
-        ]);
-    }
-
-    private function markdownFromView(string $view): Stringable
-    {
-        return str(view($view)->render())->trim();
-    }
-
-    public function submit(): void
-    {
-        auth()->user()->update(['onboarding_completed' => true]);
-
-        Notification::make()
-            ->title('Onboarding abgeschlossen')
-            ->success()
-            ->send();
+        if ($user && $user->onboarding_completed === false) {
+            $this->redirectRoute('filament.standard.pages.onboarding-wizard', [
+                'tenant' => Filament::getTenant(),
+            ]);
+        }
     }
 }

--- a/resources/views/filament/standard/pages/onboarding-wizard.blade.php
+++ b/resources/views/filament/standard/pages/onboarding-wizard.blade.php
@@ -1,0 +1,7 @@
+<x-filament-panels::page>
+    <div class="mx-auto max-w-4xl">
+        <form wire:submit.prevent="submit" class="space-y-6">
+            {{ $this->form }}
+        </form>
+    </div>
+</x-filament-panels::page>

--- a/resources/views/filament/standard/widgets/onboarding-wizard.blade.php
+++ b/resources/views/filament/standard/widgets/onboarding-wizard.blade.php
@@ -1,29 +1,19 @@
+@php use Filament\Facades\Filament; @endphp
+
 <x-filament-widgets::widget>
-    <x-filament::modal
-            id="onboarding-wizard" visible="{{ true }}" alignment="center" width="3xl"
-    >
-        <x-slot name="trigger">
-            <button
-                    x-data
-                    x-init="$nextTick(() => $el.click())"
-                    class="hidden"
-                    type="button"
+    <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+        <div class="space-y-3">
+            <div>
+                <h2 class="text-lg font-semibold text-gray-900">Willkommen im Panel 👋</h2>
+                <p class="text-sm text-gray-600">Starte hier dein Onboarding, um alle Funktionen des DashClip Panels kennenzulernen.</p>
+            </div>
+            <x-filament::button
+                tag="a"
+                href="{{ route('filament.standard.pages.onboarding-wizard', ['tenant' => Filament::getTenant()]) }}"
+                color="primary"
             >
-                Auto-open
-            </button>
-        </x-slot>
-        <x-slot name="heading">
-            Willkommen! So funktioniert DashClip:
-        </x-slot>
-
-        <form wire:submit.prevent="submit">
-            {{ $this->schema ?? $this->form }}
-        </form>
-
-        <x-slot name="footer">
-            <x-filament::button type="submit" wire:click="submit" color="primary" size="xs">
-                Nicht mehr anzeigen
+                Onboarding starten
             </x-filament::button>
-        </x-slot>
-    </x-filament::modal>
+        </div>
+    </div>
 </x-filament-widgets::widget>

--- a/tests/Feature/Filament/Standard/Pages/OnboardingWizardTest.php
+++ b/tests/Feature/Filament/Standard/Pages/OnboardingWizardTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament\Standard\Pages;
+
+use App\Enum\Guard\GuardEnum;
+use App\Enum\PanelEnum;
+use App\Filament\Standard\Pages\OnboardingWizard;
+use App\Models\User;
+use App\Repository\TeamRepository;
+use Filament\Facades\Filament;
+use Livewire\Livewire;
+use Tests\DatabaseTestCase;
+
+class OnboardingWizardTest extends DatabaseTestCase
+{
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $guard = GuardEnum::STANDARD;
+
+        $this->user = User::factory()
+            ->withOwnTeam()
+            ->standard($guard)
+            ->create([
+                'onboarding_completed' => false,
+            ]);
+
+        $tenant = app(TeamRepository::class)->getDefaultTeamForUser($this->user);
+
+        Filament::setCurrentPanel(PanelEnum::STANDARD->value);
+        Filament::setTenant($tenant, true);
+        Filament::auth()->login($this->user);
+        $this->actingAs($this->user, $guard->value);
+    }
+
+    public function testPageLoadsWizard(): void
+    {
+        Livewire::test(OnboardingWizard::class)
+            ->assertStatus(200)
+            ->assertSee('Willkommen im Standard-Panel');
+    }
+
+    public function testSubmitCompletesOnboardingAndRedirectsToDashboard(): void
+    {
+        Livewire::test(OnboardingWizard::class)
+            ->call('submit')
+            ->assertRedirect(route('filament.standard.pages.dashboard', [
+                'tenant' => Filament::getTenant(),
+            ]));
+
+        $this->assertTrue($this->user->fresh()->onboarding_completed);
+    }
+}

--- a/tests/Feature/Filament/Standard/Widgets/OnboardingWizardTest.php
+++ b/tests/Feature/Filament/Standard/Widgets/OnboardingWizardTest.php
@@ -55,26 +55,11 @@ final class OnboardingWizardTest extends DatabaseTestCase
         $this->assertFalse(OnboardingWizard::canView());
     }
 
-    public function testMountDispatchesOpenModalEvent(): void
-    {
-        $component = Livewire::test(OnboardingWizard::class);
-
-        $dispatches = data_get($component->effects, 'dispatches', []);
-
-        $this->assertNotEmpty($dispatches);
-        $this->assertSame('open-modal', $dispatches[0]['name']);
-        $this->assertSame(['id' => 'onboarding-wizard'], $dispatches[0]['params']);
-    }
-
-    public function testSubmitCompletesOnboardingAndStoresNotification(): void
+    public function testMountRedirectsToOnboardingPageWhenIncomplete(): void
     {
         Livewire::test(OnboardingWizard::class)
-            ->call('submit');
-
-        $this->assertTrue($this->user->fresh()->onboarding_completed);
-        $notifications = session('filament.notifications', []);
-
-        $this->assertNotEmpty($notifications);
-        $this->assertSame('Onboarding abgeschlossen', $notifications[0]['title']);
+            ->assertRedirect(route('filament.standard.pages.onboarding-wizard', [
+                'tenant' => $this->tenant,
+            ]));
     }
 }


### PR DESCRIPTION
## Summary
- redirect from the onboarding widget using Livewire's redirect helper to avoid invalid redirector dehydrate errors

## Testing
- php -d memory_limit=512M ./vendor/bin/phpunit --no-coverage --filter OnboardingWizard


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c5f04441c8329a0ac1fec83175a4b)