### PR TITLE
Make onboarding flow tenant-aware and static

### DIFF
--- a/app/Filament/Standard/Pages/Onboarding.php
+++ b/app/Filament/Standard/Pages/Onboarding.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Filament\Standard\Pages;
+
+use BezhanSalleh\FilamentShield\Traits\HasPageShield;
+use Filament\Facades\Filament;
+use Filament\Forms\Components\View as ViewField;
+use Filament\Forms\Components\Wizard;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Forms\Form;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+use Filament\Support\Enums\Alignment;
+
+class Onboarding extends Page implements HasForms
+{
+    use InteractsWithForms;
+    use HasPageShield;
+
+    protected static ?string $slug = 'onboarding';
+    protected static bool $shouldRegisterNavigation = false;
+    protected static ?string $title = 'Onboarding';
+    protected string $view = 'filament.standard.pages.onboarding';
+
+    public ?array $data = [];
+
+    public function mount(): void
+    {
+        if (auth()->user()?->onboarding_completed) {
+            $this->redirect(
+                route('filament.standard.pages.dashboard', ['tenant' => Filament::getTenant()?->getKey()]),
+                navigate: true,
+            );
+
+            return;
+        }
+
+        $this->form->fill();
+    }
+
+    public function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Wizard::make([
+                    Wizard\Step::make('Willkommen')
+                        ->schema([
+                            ViewField::make('intro')
+                                ->view('onboarding.steps.welcome'),
+                        ]),
+                    Wizard\Step::make('Video-Upload')
+                        ->schema([
+                            ViewField::make('video-upload')
+                                ->view('onboarding.steps.video-upload'),
+                        ]),
+                    Wizard\Step::make('Kanal-Auswahl')
+                        ->schema([
+                            ViewField::make('channel-selection')
+                                ->view('onboarding.steps.channel-selection'),
+                        ]),
+                    Wizard\Step::make('Video-Management')
+                        ->schema([
+                            ViewField::make('video-management')
+                                ->view('onboarding.steps.video-management'),
+                        ]),
+                    Wizard\Step::make('Fertig')
+                        ->schema([
+                            ViewField::make('done')
+                                ->view('onboarding.steps.finished'),
+                        ]),
+                ])
+                    ->submitActionAlignment(Alignment::Right)
+                    ->skippable(false),
+            ])
+            ->statePath('data');
+    }
+
+    public function submit(): void
+    {
+        auth()->user()->update(['onboarding_completed' => true]);
+
+        Notification::make()
+            ->title('Onboarding abgeschlossen')
+            ->success()
+            ->send();
+
+        $this->redirect(
+            route('filament.standard.pages.dashboard', ['tenant' => Filament::getTenant()?->getKey()]),
+            navigate: true,
+        );
+    }
+}

--- a/app/Filament/Standard/Widgets/OnboardingWizard.php
+++ b/app/Filament/Standard/Widgets/OnboardingWizard.php
@@ -3,92 +3,17 @@
 namespace App\Filament\Standard\Widgets;
 
 use BezhanSalleh\FilamentShield\Traits\HasWidgetShield;
-use Filament\Forms\Concerns\InteractsWithForms;
-use Filament\Forms\Contracts\HasForms;
-use Filament\Infolists\Components\TextEntry;
-use Filament\Notifications\Notification;
-use Filament\Schemas\Components\Wizard;
-use Filament\Schemas\Schema;
 use Filament\Widgets\Widget;
-use Illuminate\Support\Stringable;
 
-class OnboardingWizard extends Widget implements HasForms
+class OnboardingWizard extends Widget
 {
-    use InteractsWithForms;
     use HasWidgetShield;
 
-    protected static ?string $modalId = 'onboarding-wizard';
     protected string $view = 'filament.standard.widgets.onboarding-wizard';
     protected static bool $isLazy = false;
-
-    public function mount(): void
-    {
-        if (static::canView()) {
-            $this->dispatch('open-modal', id: static::$modalId);
-        }
-    }
 
     public static function canView(): bool
     {
         return auth()->user()?->onboarding_completed === false;
-    }
-
-    public function form(Schema $schema): Schema
-    {
-        return $schema->components([
-            Wizard::make([
-
-                Wizard\Step::make('Willkommen')
-                    ->schema([
-                        TextEntry::make('intro')
-                            ->state($this->markdownFromView('onboarding.steps.welcome'))
-                            ->markdown(),
-                    ]),
-
-                Wizard\Step::make('Video-Upload')
-                    ->schema([
-                        TextEntry::make('video-upload')
-                            ->state($this->markdownFromView('onboarding.steps.video-upload'))
-                            ->markdown(),
-                    ]),
-
-                Wizard\Step::make('Kanal-Auswahl')
-                    ->schema([
-                        TextEntry::make('channel-selection')
-                            ->state($this->markdownFromView('onboarding.steps.channel-selection'))
-                            ->markdown(),
-                    ]),
-
-                Wizard\Step::make('Video-Management')
-                    ->schema([
-                        TextEntry::make('video-management')
-                            ->state($this->markdownFromView('onboarding.steps.video-management'))
-                            ->markdown(),
-                    ]),
-
-                Wizard\Step::make('Fertig')
-                    ->schema([
-                        TextEntry::make('done')
-                            ->state($this->markdownFromView('onboarding.steps.finished'))
-                            ->markdown(),
-                    ]),
-
-            ]),
-        ]);
-    }
-
-    private function markdownFromView(string $view): Stringable
-    {
-        return str(view($view)->render())->trim();
-    }
-
-    public function submit(): void
-    {
-        auth()->user()->update(['onboarding_completed' => true]);
-
-        Notification::make()
-            ->title('Onboarding abgeschlossen')
-            ->success()
-            ->send();
     }
 }

--- a/resources/views/filament/standard/pages/onboarding.blade.php
+++ b/resources/views/filament/standard/pages/onboarding.blade.php
@@ -1,0 +1,11 @@
+<x-filament-panels::page>
+    <form wire:submit.prevent="submit" class="space-y-6">
+        {{ $this->form }}
+
+        <div class="flex justify-end">
+            <x-filament::button type="submit" color="primary">
+                Onboarding abschließen
+            </x-filament::button>
+        </div>
+    </form>
+</x-filament-panels::page>

--- a/resources/views/filament/standard/widgets/onboarding-wizard.blade.php
+++ b/resources/views/filament/standard/widgets/onboarding-wizard.blade.php
@@ -1,29 +1,22 @@
 <x-filament-widgets::widget>
-    <x-filament::modal
-            id="onboarding-wizard" visible="{{ true }}" alignment="center" width="3xl"
-    >
-        <x-slot name="trigger">
-            <button
-                    x-data
-                    x-init="$nextTick(() => $el.click())"
-                    class="hidden"
-                    type="button"
+    <x-filament::section>
+        <div class="space-y-4">
+            <div class="space-y-2">
+                <h3 class="text-base font-semibold text-gray-900 dark:text-gray-100">
+                    Willkommen! So funktioniert DashClip
+                </h3>
+                <p class="text-sm text-gray-600 dark:text-gray-400">
+                    Durchlaufe unser kurzes Onboarding, um einen Überblick über Upload, Kanal-Auswahl und Videomanagement zu erhalten.
+                </p>
+            </div>
+
+            <x-filament::button
+                tag="a"
+                color="primary"
+                href="{{ route('filament.standard.pages.onboarding', ['tenant' => \Filament\Facades\Filament::getTenant()?->getKey()]) }}"
             >
-                Auto-open
-            </button>
-        </x-slot>
-        <x-slot name="heading">
-            Willkommen! So funktioniert DashClip:
-        </x-slot>
-
-        <form wire:submit.prevent="submit">
-            {{ $this->schema ?? $this->form }}
-        </form>
-
-        <x-slot name="footer">
-            <x-filament::button type="submit" wire:click="submit" color="primary" size="xs">
-                Nicht mehr anzeigen
+                Onboarding starten
             </x-filament::button>
-        </x-slot>
-    </x-filament::modal>
+        </div>
+    </x-filament::section>
 </x-filament-widgets::widget>

--- a/tests/Feature/Filament/Standard/Widgets/OnboardingWizardTest.php
+++ b/tests/Feature/Filament/Standard/Widgets/OnboardingWizardTest.php
@@ -55,26 +55,16 @@ final class OnboardingWizardTest extends DatabaseTestCase
         $this->assertFalse(OnboardingWizard::canView());
     }
 
-    public function testMountDispatchesOpenModalEvent(): void
+    public function testRendersStaticCtaLinkWithoutDispatches(): void
     {
         $component = Livewire::test(OnboardingWizard::class);
 
         $dispatches = data_get($component->effects, 'dispatches', []);
 
-        $this->assertNotEmpty($dispatches);
-        $this->assertSame('open-modal', $dispatches[0]['name']);
-        $this->assertSame(['id' => 'onboarding-wizard'], $dispatches[0]['params']);
-    }
+        $this->assertSame([], $dispatches);
 
-    public function testSubmitCompletesOnboardingAndStoresNotification(): void
-    {
-        Livewire::test(OnboardingWizard::class)
-            ->call('submit');
-
-        $this->assertTrue($this->user->fresh()->onboarding_completed);
-        $notifications = session('filament.notifications', []);
-
-        $this->assertNotEmpty($notifications);
-        $this->assertSame('Onboarding abgeschlossen', $notifications[0]['title']);
+        $component
+            ->assertSee('Onboarding starten')
+            ->assertSee(route('filament.standard.pages.onboarding', ['tenant' => $this->tenant->getKey()]));
     }
 }


### PR DESCRIPTION
## Summary
- ensure onboarding page redirects are tenant-aware and avoid redirects from the widget
- render the onboarding widget as a static CTA linking to the onboarding page with the current tenant
- update onboarding widget tests to verify the static CTA behavior instead of modal dispatches

## Testing
- ✅ `XDEBUG_MODE=coverage php -d memory_limit=512M vendor/bin/phpunit tests/Feature/Filament/Standard/Widgets/OnboardingWizardTest.php`
- ❌ `XDEBUG_MODE=coverage php -d memory_limit=1G vendor/bin/phpunit` *(fails: tenant route parameter now required in widget tests prior to fix, missing ffmpeg binary, and ingest scan expectations differ in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c6ee1c3988329a14295d17b9a5e6f)