### PR TITLE
Add ChannelTeamResource feature tests

### DIFF
--- a/tests/Feature/Filament/Standard/Resources/ChannelTeamResource/Pages/CreateChannelTeamTest.php
+++ b/tests/Feature/Filament/Standard/Resources/ChannelTeamResource/Pages/CreateChannelTeamTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament\Standard\Resources\ChannelTeamResource\Pages;
+
+use App\Enum\Guard\GuardEnum;
+use App\Enum\PanelEnum;
+use App\Filament\Standard\Resources\ChannelTeamResource\Pages\CreateChannelTeam;
+use App\Models\Channel;
+use App\Models\Pivots\ChannelTeamPivot;
+use App\Models\Team;
+use App\Models\User;
+use App\Repository\TeamRepository;
+use Filament\Facades\Filament;
+use Livewire\Livewire;
+use Tests\DatabaseTestCase;
+
+final class CreateChannelTeamTest extends DatabaseTestCase
+{
+    private User $user;
+
+    private Team $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()
+            ->withOwnTeam()
+            ->admin(GuardEnum::STANDARD)
+            ->create();
+
+        $this->tenant = app(TeamRepository::class)->getDefaultTeamForUser($this->user);
+
+        Filament::setCurrentPanel(PanelEnum::STANDARD->value);
+        Filament::setTenant($this->tenant, true);
+        Filament::auth()->login($this->user);
+        $this->actingAs($this->user, GuardEnum::STANDARD->value);
+    }
+
+    public function testCreateChannelTeamStoresRecordForCurrentTenant(): void
+    {
+        $channel = Channel::factory()->create();
+
+        Livewire::test(CreateChannelTeam::class)
+            ->assertStatus(200)
+            ->fillForm([
+                'channel_id' => $channel->getKey(),
+                'quota' => 9,
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        $this->assertDatabaseHas(ChannelTeamPivot::class, [
+            'team_id' => $this->tenant->getKey(),
+            'channel_id' => $channel->getKey(),
+            'quota' => 9,
+        ]);
+    }
+}

--- a/tests/Feature/Filament/Standard/Resources/ChannelTeamResource/Pages/EditChannelTeamTest.php
+++ b/tests/Feature/Filament/Standard/Resources/ChannelTeamResource/Pages/EditChannelTeamTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament\Standard\Resources\ChannelTeamResource\Pages;
+
+use App\Enum\Guard\GuardEnum;
+use App\Enum\PanelEnum;
+use App\Filament\Standard\Resources\ChannelTeamResource\Pages\EditChannelTeam;
+use App\Models\Channel;
+use App\Models\Pivots\ChannelTeamPivot;
+use App\Models\Team;
+use App\Models\User;
+use App\Repository\TeamRepository;
+use Filament\Facades\Filament;
+use Livewire\Livewire;
+use Tests\DatabaseTestCase;
+
+final class EditChannelTeamTest extends DatabaseTestCase
+{
+    private User $user;
+
+    private Team $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()
+            ->withOwnTeam()
+            ->admin(GuardEnum::STANDARD)
+            ->create();
+
+        $this->tenant = app(TeamRepository::class)->getDefaultTeamForUser($this->user);
+
+        Filament::setCurrentPanel(PanelEnum::STANDARD->value);
+        Filament::setTenant($this->tenant, true);
+        Filament::auth()->login($this->user);
+        $this->actingAs($this->user, GuardEnum::STANDARD->value);
+    }
+
+    public function testEditChannelTeamUpdatesQuota(): void
+    {
+        $channel = Channel::factory()->create();
+
+        $channelTeam = ChannelTeamPivot::query()->create([
+            'team_id' => $this->tenant->getKey(),
+            'channel_id' => $channel->getKey(),
+            'quota' => 6,
+        ]);
+
+        Livewire::test(EditChannelTeam::class, ['record' => $channelTeam->getKey()])
+            ->assertStatus(200)
+            ->assertFormSet([
+                'channel_id' => $channel->getKey(),
+                'quota' => 6,
+            ])
+            ->fillForm(['quota' => 11])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $channelTeam->refresh();
+
+        $this->assertSame(11, $channelTeam->quota);
+    }
+}

--- a/tests/Feature/Filament/Standard/Resources/ChannelTeamResource/Pages/ListChannelTeamsTest.php
+++ b/tests/Feature/Filament/Standard/Resources/ChannelTeamResource/Pages/ListChannelTeamsTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament\Standard\Resources\ChannelTeamResource\Pages;
+
+use App\Enum\Guard\GuardEnum;
+use App\Enum\PanelEnum;
+use App\Filament\Standard\Resources\ChannelTeamResource\Pages\ListChannelTeams;
+use App\Models\Channel;
+use App\Models\Pivots\ChannelTeamPivot;
+use App\Models\Team;
+use App\Models\User;
+use App\Repository\TeamRepository;
+use Filament\Facades\Filament;
+use Livewire\Livewire;
+use Tests\DatabaseTestCase;
+
+final class ListChannelTeamsTest extends DatabaseTestCase
+{
+    private User $user;
+
+    private Team $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()
+            ->withOwnTeam()
+            ->admin(GuardEnum::STANDARD)
+            ->create();
+
+        $this->tenant = app(TeamRepository::class)->getDefaultTeamForUser($this->user);
+
+        Filament::setCurrentPanel(PanelEnum::STANDARD->value);
+        Filament::setTenant($this->tenant, true);
+        Filament::auth()->login($this->user);
+        $this->actingAs($this->user, GuardEnum::STANDARD->value);
+    }
+
+    public function testListChannelTeamsShowsOnlyTenantRecords(): void
+    {
+        $channel = Channel::factory()->create();
+        $otherChannel = Channel::factory()->create();
+
+        $tenantChannelTeam = ChannelTeamPivot::query()->create([
+            'team_id' => $this->tenant->getKey(),
+            'channel_id' => $channel->getKey(),
+            'quota' => 5,
+        ]);
+
+        $otherTeam = Team::factory()->create();
+        $otherChannelTeam = ChannelTeamPivot::query()->create([
+            'team_id' => $otherTeam->getKey(),
+            'channel_id' => $otherChannel->getKey(),
+            'quota' => 7,
+        ]);
+
+        Livewire::test(ListChannelTeams::class)
+            ->assertStatus(200)
+            ->assertCanSeeTableRecords([$tenantChannelTeam])
+            ->assertCanNotSeeTableRecords([$otherChannelTeam])
+            ->assertTableColumnStateSet('channel.name', $channel->name, record: $tenantChannelTeam)
+            ->assertTableColumnStateSet('quota', 5, record: $tenantChannelTeam);
+    }
+}

--- a/tests/Feature/Filament/Standard/Resources/ChannelTeamResourceTest.php
+++ b/tests/Feature/Filament/Standard/Resources/ChannelTeamResourceTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament\Standard\Resources;
+
+use App\Enum\Guard\GuardEnum;
+use App\Enum\PanelEnum;
+use App\Filament\Standard\Resources\ChannelTeamResource;
+use App\Models\Channel;
+use App\Models\Pivots\ChannelTeamPivot;
+use App\Models\Team;
+use App\Models\User;
+use App\Repository\TeamRepository;
+use Filament\Facades\Filament;
+use Tests\DatabaseTestCase;
+
+final class ChannelTeamResourceTest extends DatabaseTestCase
+{
+    private User $user;
+
+    private Team $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()
+            ->withOwnTeam()
+            ->admin(GuardEnum::STANDARD)
+            ->create();
+
+        $this->tenant = app(TeamRepository::class)->getDefaultTeamForUser($this->user);
+
+        Filament::setCurrentPanel(PanelEnum::STANDARD->value);
+        Filament::setTenant($this->tenant, true);
+        Filament::auth()->login($this->user);
+        $this->actingAs($this->user, GuardEnum::STANDARD->value);
+    }
+
+    public function testEloquentQueryReturnsOnlyRecordsFromCurrentTenant(): void
+    {
+        $channel = Channel::factory()->create();
+        $tenantChannelTeam = ChannelTeamPivot::query()->create([
+            'team_id' => $this->tenant->getKey(),
+            'channel_id' => $channel->getKey(),
+            'quota' => 8,
+        ]);
+
+        $otherTeam = Team::factory()->create();
+        $otherChannel = Channel::factory()->create();
+        $otherChannelTeam = ChannelTeamPivot::query()->create([
+            'team_id' => $otherTeam->getKey(),
+            'channel_id' => $otherChannel->getKey(),
+            'quota' => 12,
+        ]);
+
+        $records = ChannelTeamResource::getEloquentQuery()->get();
+
+        $this->assertTrue($records->contains(fn(ChannelTeamPivot $record) => $record->is($tenantChannelTeam)));
+        $this->assertFalse($records->contains(fn(ChannelTeamPivot $record) => $record->is($otherChannelTeam)));
+        $this->assertSame([$tenantChannelTeam->getKey()], $records->pluck('id')->all());
+    }
+}


### PR DESCRIPTION
## Summary
- add tenant-aware feature coverage for ChannelTeamResource and its Filament Standard pages
- verify listing visibility, creation, and editing behavior for channel-team assignments

## Testing
- ./vendor/bin/phpunit --testsuite Feature --no-coverage --filter ChannelTeamResource


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930991edb248329a1318e5aa9c52ea1)