### PR TITLE
Add feature tests for standard auth pages

### DIFF
--- a/tests/Feature/Standard/Pages/Auth/EditTenantProfilePageTest.php
+++ b/tests/Feature/Standard/Pages/Auth/EditTenantProfilePageTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Standard\Pages\Auth;
+
+use App\Filament\Standard\Pages\Auth\EditTenantProfile;
+use PHPUnit\Framework\TestCase;
+
+final class EditTenantProfilePageTest extends TestCase
+{
+    public function testGetLabelReturnsProfile(): void
+    {
+        $this->assertSame('Profile', EditTenantProfile::getLabel());
+    }
+}

--- a/tests/Feature/Standard/Pages/Auth/RegisterPageTest.php
+++ b/tests/Feature/Standard/Pages/Auth/RegisterPageTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Standard\Pages\Auth;
+
+use App\Enum\Guard\GuardEnum;
+use App\Enum\PanelEnum;
+use App\Enum\Users\RoleEnum;
+use App\Filament\Standard\Pages\Auth\Register;
+use Filament\Facades\Filament;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Role;
+use Tests\DatabaseTestCase;
+
+final class RegisterPageTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('auth.defaults.guard', GuardEnum::STANDARD->value);
+
+        Filament::setCurrentPanel(Filament::getPanel(PanelEnum::STANDARD->value));
+    }
+
+    public function testRegistrationAssignsRegularRoleToNewUser(): void
+    {
+        Role::findOrCreate(RoleEnum::REGULAR->value, GuardEnum::STANDARD->value);
+
+        $registrationData = [
+            'name' => 'Test User',
+            'email' => 'user@example.com',
+            'password' => 'secret-password',
+            'passwordConfirmation' => 'secret-password',
+        ];
+
+        Livewire::test(Register::class)
+            ->fillForm($registrationData)
+            ->call('register')
+            ->assertHasNoFormErrors();
+
+        $user = Filament::auth()->user();
+
+        $this->assertNotNull($user);
+        $this->assertTrue($user->hasRole(RoleEnum::REGULAR->value));
+    }
+}


### PR DESCRIPTION
## Summary
- add a feature test for the standard register page to ensure new users receive the regular role
- add a feature test confirming the tenant profile page label

## Testing
- ./vendor/bin/phpunit --no-coverage tests/Feature/Standard/Pages/Auth

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930a0f84be88329b376d827445689cd)