### PR TITLE
Add feature tests for Filament Channel resource

### DIFF
--- a/tests/Feature/Resources/Channels/ChannelResourceTest.php
+++ b/tests/Feature/Resources/Channels/ChannelResourceTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Resources\Channels;
+
+use App\Filament\Resources\Channels\ChannelResource;
+use App\Filament\Resources\Channels\Pages\CreateChannel;
+use App\Filament\Resources\Channels\Pages\EditChannel;
+use App\Filament\Resources\Channels\Pages\ListChannels;
+use App\Models\Channel;
+use App\Models\User;
+use Filament\Resources\Pages\PageRegistration;
+use Tests\DatabaseTestCase;
+
+final class ChannelResourceTest extends DatabaseTestCase
+{
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->admin()->create();
+        $this->actingAs($this->admin, 'web');
+    }
+
+    public function testResourceMetadataMatchesChannelModel(): void
+    {
+        $this->assertSame(Channel::class, ChannelResource::getModel());
+        $this->assertSame('heroicon-o-envelope', ChannelResource::getNavigationIcon());
+        $this->assertSame('Media', ChannelResource::getNavigationGroup());
+        $this->assertSame('Channel', ChannelResource::getModelLabel());
+        $this->assertSame('Channels', ChannelResource::getPluralModelLabel());
+    }
+
+    public function testResourceRegistersExpectedPages(): void
+    {
+        $pages = ChannelResource::getPages();
+
+        $this->assertArrayHasKey('index', $pages);
+        $this->assertArrayHasKey('create', $pages);
+        $this->assertArrayHasKey('edit', $pages);
+
+        $this->assertInstanceOf(PageRegistration::class, $pages['index']);
+        $this->assertInstanceOf(PageRegistration::class, $pages['create']);
+        $this->assertInstanceOf(PageRegistration::class, $pages['edit']);
+
+        $this->assertSame(ListChannels::class, $pages['index']->getPage());
+        $this->assertSame(CreateChannel::class, $pages['create']->getPage());
+        $this->assertSame(EditChannel::class, $pages['edit']->getPage());
+    }
+}

--- a/tests/Feature/Resources/Channels/Pages/CreateChannelTest.php
+++ b/tests/Feature/Resources/Channels/Pages/CreateChannelTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Resources\Channels\Pages;
+
+use App\Events\ChannelCreated;
+use App\Filament\Resources\Channels\Pages\CreateChannel;
+use App\Models\Channel;
+use App\Models\User;
+use Illuminate\Support\Facades\Event;
+use Livewire\Livewire;
+use Tests\DatabaseTestCase;
+
+final class CreateChannelTest extends DatabaseTestCase
+{
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->admin()->create();
+        $this->actingAs($this->admin, 'web');
+    }
+
+    public function testCreateChannelStoresRecordAndDispatchesEvent(): void
+    {
+        Event::fake([ChannelCreated::class]);
+
+        $formData = [
+            'name' => 'Tech Daily',
+            'creator_name' => 'Alex Example',
+            'email' => 'channel@example.com',
+            'youtube_name' => 'tech-daily',
+            'weight' => 5,
+            'weekly_quota' => 3,
+            'is_video_reception_paused' => true,
+        ];
+
+        Livewire::test(CreateChannel::class)
+            ->assertStatus(200)
+            ->fillForm($formData)
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        $this->assertDatabaseHas(Channel::class, [
+            'name' => 'Tech Daily',
+            'creator_name' => 'Alex Example',
+            'email' => 'channel@example.com',
+            'youtube_name' => 'tech-daily',
+            'weight' => 5,
+            'weekly_quota' => 3,
+            'is_video_reception_paused' => true,
+        ]);
+
+        Event::assertDispatched(ChannelCreated::class, function (ChannelCreated $event) {
+            return $event->channel->name === 'Tech Daily';
+        });
+    }
+}

--- a/tests/Feature/Resources/Channels/Pages/EditChannelTest.php
+++ b/tests/Feature/Resources/Channels/Pages/EditChannelTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Resources\Channels\Pages;
+
+use App\Filament\Resources\Channels\Pages\EditChannel;
+use App\Models\Channel;
+use App\Models\User;
+use Livewire\Livewire;
+use Tests\DatabaseTestCase;
+
+final class EditChannelTest extends DatabaseTestCase
+{
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->admin()->create();
+        $this->actingAs($this->admin, 'web');
+    }
+
+    public function testEditChannelFormLoadsAndUpdatesRecord(): void
+    {
+        $channel = Channel::factory()->create([
+            'name' => 'Original Channel',
+            'creator_name' => 'First Creator',
+            'email' => 'first@example.com',
+            'youtube_name' => 'original-yt',
+            'weight' => 1,
+            'weekly_quota' => 2,
+            'is_video_reception_paused' => false,
+        ]);
+
+        Livewire::test(EditChannel::class, ['record' => $channel->getKey()])
+            ->assertStatus(200)
+            ->assertFormSet([
+                'name' => 'Original Channel',
+                'creator_name' => 'First Creator',
+                'email' => 'first@example.com',
+                'youtube_name' => 'original-yt',
+                'weight' => 1,
+                'weekly_quota' => 2,
+                'is_video_reception_paused' => false,
+            ])
+            ->fillForm([
+                'name' => 'Updated Channel',
+                'creator_name' => 'New Creator',
+                'email' => 'updated@example.com',
+                'youtube_name' => 'updated-yt',
+                'weight' => 3,
+                'weekly_quota' => 5,
+                'is_video_reception_paused' => true,
+            ])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $channel->refresh();
+
+        $this->assertSame('Updated Channel', $channel->name);
+        $this->assertSame('New Creator', $channel->creator_name);
+        $this->assertSame('updated@example.com', $channel->email);
+        $this->assertSame('updated-yt', $channel->youtube_name);
+        $this->assertSame(3, $channel->weight);
+        $this->assertSame(5, $channel->weekly_quota);
+        $this->assertTrue($channel->is_video_reception_paused);
+    }
+}

--- a/tests/Feature/Resources/Channels/Pages/ListChannelsTest.php
+++ b/tests/Feature/Resources/Channels/Pages/ListChannelsTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Resources\Channels\Pages;
+
+use App\Filament\Resources\Channels\Pages\ListChannels;
+use App\Models\Channel;
+use App\Models\User;
+use Livewire\Livewire;
+use Tests\DatabaseTestCase;
+
+final class ListChannelsTest extends DatabaseTestCase
+{
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->admin()->create();
+        $this->actingAs($this->admin, 'web');
+    }
+
+    public function testListChannelsDisplaysColumnsAndRecords(): void
+    {
+        $firstChannel = Channel::factory()->create([
+            'name' => 'Alpha Channel',
+            'creator_name' => 'Creator One',
+            'email' => 'creator1@example.com',
+            'youtube_name' => 'alpha-yt',
+        ]);
+
+        $secondChannel = Channel::factory()->create([
+            'name' => 'Beta Channel',
+            'creator_name' => 'Creator Two',
+            'email' => 'creator2@example.com',
+            'youtube_name' => 'beta-yt',
+        ]);
+
+        Livewire::test(ListChannels::class)
+            ->assertStatus(200)
+            ->assertCanSeeTableRecords([$firstChannel, $secondChannel])
+            ->assertTableColumnExists('name')
+            ->assertTableColumnExists('creator_name')
+            ->assertTableColumnExists('email')
+            ->assertTableColumnExists('youtube_name')
+            ->assertTableColumnExists('weight')
+            ->assertTableColumnExists('weekly_quota')
+            ->assertTableColumnExists('created_at')
+            ->assertTableColumnExists('updated_at')
+            ->assertTableColumnExists('is_video_reception_paused');
+    }
+}


### PR DESCRIPTION
## Summary
- add feature coverage for Filament Channel resource metadata and pages
- verify list, create, and edit Channel page behaviors with Livewire

## Testing
- ./vendor/bin/phpunit --no-coverage tests/Feature/Resources/Channels

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930be1fd8108329b5f98dd24a644691)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for Channel resource management, including tests for channel creation with event verification, editing functionality, listing display with table columns, and resource configuration validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->