### PR TITLE
Add integration tests for notification preferences

### DIFF
--- a/tests/Integration/Filament/Pages/Auth/EditProfileNotificationsTest.php
+++ b/tests/Integration/Filament/Pages/Auth/EditProfileNotificationsTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Filament\Pages\Auth;
+
+use App\Filament\Pages\Auth\EditProfile;
+use App\Models\User;
+use App\Notifications\UserUploadDuplicatedNotification;
+use App\Notifications\UserUploadProceedNotification;
+use App\Repository\UserMailConfigRepository;
+use Livewire\Livewire;
+use Tests\DatabaseTestCase;
+
+final class EditProfileNotificationsTest extends DatabaseTestCase
+{
+    public function testNotificationPreferencesRenderedWithDefaults(): void
+    {
+        $user = User::factory()->create();
+        $repository = app(UserMailConfigRepository::class);
+
+        $repository->setForUser($user, UserUploadDuplicatedNotification::class, false);
+        $repository->setForUser($user, UserUploadProceedNotification::class, true);
+
+        $this->actingAs($user);
+
+        Livewire::test(EditProfile::class)
+            ->assertFormFieldExists('notifications.mail.types.' . UserUploadDuplicatedNotification::class)
+            ->assertFormFieldExists('notifications.mail.types.' . UserUploadProceedNotification::class)
+            ->assertSet('data.notifications.mail.types.' . UserUploadDuplicatedNotification::class, false)
+            ->assertSet('data.notifications.mail.types.' . UserUploadProceedNotification::class, true);
+    }
+}

--- a/tests/Integration/Notifications/NotificationPreferencesTest.php
+++ b/tests/Integration/Notifications/NotificationPreferencesTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Notifications;
+
+use App\Models\User;
+use App\Notifications\UserUploadDuplicatedNotification;
+use App\Notifications\UserUploadProceedNotification;
+use App\Repository\UserMailConfigRepository;
+use Tests\DatabaseTestCase;
+
+final class NotificationPreferencesTest extends DatabaseTestCase
+{
+    public function testMailChannelIsRemovedWhenOptedOut(): void
+    {
+        $user = User::factory()->create();
+        $repository = app(UserMailConfigRepository::class);
+        $repository->setForUser($user, UserUploadDuplicatedNotification::class, false);
+
+        $notification = new UserUploadDuplicatedNotification('example.mov');
+
+        $channels = $notification->via($user);
+
+        $this->assertNotContains('mail', $channels);
+        $this->assertContains('database', $channels);
+    }
+
+    public function testMailChannelRespectsDefaultOptIn(): void
+    {
+        $user = User::factory()->create();
+        $notification = new UserUploadProceedNotification('example.mov');
+
+        $channels = $notification->via($user);
+
+        $this->assertContains('mail', $channels);
+        $this->assertContains('database', $channels);
+    }
+}

--- a/tests/Integration/Repository/UserMailConfigRepositoryTest.php
+++ b/tests/Integration/Repository/UserMailConfigRepositoryTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Repository;
+
+use App\Models\User;
+use App\Models\UserMailConfig;
+use App\Repository\UserMailConfigRepository;
+use Tests\DatabaseTestCase;
+
+final class UserMailConfigRepositoryTest extends DatabaseTestCase
+{
+    public function testGetAndSetNotificationPreference(): void
+    {
+        $user = User::factory()->create();
+        $repository = app(UserMailConfigRepository::class);
+
+        $repository->setForUser($user, 'test.notification', false);
+
+        $this->assertDatabaseHas(UserMailConfig::class, [
+            'user_id' => $user->id,
+            'key' => 'test.notification',
+            'value' => false,
+        ]);
+
+        $this->assertFalse($repository->getForUser($user, 'test.notification'));
+    }
+
+    public function testIsAllowedUsesDefaultWhenMissing(): void
+    {
+        $user = User::factory()->create();
+        $repository = app(UserMailConfigRepository::class);
+
+        $this->assertTrue($repository->isAllowed($user, 'missing.notification', true));
+        $this->assertFalse($repository->isAllowed($user, 'missing.notification', false));
+    }
+
+    public function testAllForUserReturnsStoredPreferences(): void
+    {
+        $user = User::factory()->create();
+        $repository = app(UserMailConfigRepository::class);
+
+        $repository->setForUser($user, 'first.notification', true);
+        $repository->setForUser($user, 'second.notification', false);
+
+        $this->assertSame(
+            [
+                'first.notification' => true,
+                'second.notification' => false,
+            ],
+            $repository->allForUser($user)
+        );
+    }
+}

--- a/tests/Integration/Services/NotificationDiscoveryServiceTest.php
+++ b/tests/Integration/Services/NotificationDiscoveryServiceTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Services;
+
+use App\Notifications\UserUploadDuplicatedNotification;
+use App\Notifications\UserUploadProceedNotification;
+use App\Providers\ServiceServiceProvider;
+use App\Services\Notifications\Decorator\CachedNotificationDiscoveryService;
+use App\Services\Notifications\NotificationDiscoveryService;
+use Illuminate\Support\Facades\Cache;
+use Mockery;
+use Tests\TestCase;
+
+final class NotificationDiscoveryServiceTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    protected function getPackageProviders($app): array
+    {
+        return [
+            ServiceServiceProvider::class,
+        ];
+    }
+
+    public function testListsUserFacingNotifications(): void
+    {
+        $service = app(NotificationDiscoveryService::class, ['useCache' => false]);
+
+        $result = $service->list();
+
+        $this->assertContains(UserUploadDuplicatedNotification::class, $result);
+        $this->assertContains(UserUploadProceedNotification::class, $result);
+    }
+
+    public function testBindingAllowsDisablingCache(): void
+    {
+        $service = app(NotificationDiscoveryService::class, ['useCache' => false]);
+
+        $this->assertInstanceOf(NotificationDiscoveryService::class, $service);
+        $this->assertNotInstanceOf(CachedNotificationDiscoveryService::class, $service);
+    }
+
+    public function testCachedDecoratorUsesConfiguredTtl(): void
+    {
+        Cache::shouldReceive('remember')
+            ->once()
+            ->with('notification_discovery', 600, Mockery::type('Closure'))
+            ->andReturn(['cached']);
+
+        $service = app(NotificationDiscoveryService::class, [
+            'ttl' => 600,
+            'useCache' => true,
+        ]);
+
+        $this->assertInstanceOf(CachedNotificationDiscoveryService::class, $service);
+        $this->assertSame(['cached'], $service->list());
+    }
+}


### PR DESCRIPTION
## Summary
- add coverage for notification discovery including cache decorator binding
- verify user mail configuration repository behavior for opt-in/out storage
- ensure notification channel selection and Filament profile form reflect user preferences

## Testing
- vendor/bin/phpunit --no-coverage --testsuite Integration --filter NotificationDiscoveryServiceTest
- vendor/bin/phpunit --no-coverage --testsuite Integration --filter NotificationPreferencesTest
- vendor/bin/phpunit --no-coverage --testsuite Integration --filter UserMailConfigRepositoryTest
- vendor/bin/phpunit --no-coverage --testsuite Integration --filter EditProfileNotificationsTest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930d91928508329a8dc5479b539b3a6)