### PR TITLE
Add integration tests for user mail config and notification discovery

### DIFF
--- a/app/Models/Pivots/ModelHasRoleTeam.php
+++ b/app/Models/Pivots/ModelHasRoleTeam.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Models\Pivots;
 
-use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Database\Eloquent\Relations\MorphPivot;
 
-class ModelHasRoleTeam extends Pivot
+class ModelHasRoleTeam extends MorphPivot
 {
     protected $table = 'model_has_roles';
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -173,13 +173,18 @@ class User extends Authenticatable implements FilamentUser, HasAppAuthentication
 
     public function teamRoles(): MorphToMany|BelongsToMany
     {
-        return $this->morphToMany(
+        $relation = $this->morphToMany(
             \Spatie\Permission\Models\Role::class,
             'model',
             'model_has_roles'
         )
-            ->using(ModelHasRoleTeam::class)
-            ->withPivot('team_id');
+            ->using(ModelHasRoleTeam::class);
+
+        if (config('permission.teams')) {
+            $relation->withPivot('team_id');
+        }
+
+        return $relation;
     }
 
 

--- a/app/Models/UserMailConfig.php
+++ b/app/Models/UserMailConfig.php
@@ -3,10 +3,13 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class UserMailConfig extends Model
 {
+    use HasFactory;
+
     protected $fillable = [
         'user_id',
         'key',

--- a/database/factories/UserMailConfigFactory.php
+++ b/database/factories/UserMailConfigFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\User;
+use App\Models\UserMailConfig;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<UserMailConfig> */
+class UserMailConfigFactory extends Factory
+{
+    protected $model = UserMailConfig::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'key' => $this->faker->unique()->slug(),
+            'value' => $this->faker->boolean(),
+        ];
+    }
+
+    public function forUser(User $user): self
+    {
+        return $this->state(fn() => [
+            'user_id' => $user->getKey(),
+        ]);
+    }
+}

--- a/tests/Integration/Models/UserMailConfigTest.php
+++ b/tests/Integration/Models/UserMailConfigTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Models;
+
+use App\Models\User;
+use App\Models\UserMailConfig;
+use Tests\DatabaseTestCase;
+
+final class UserMailConfigTest extends DatabaseTestCase
+{
+    public function testFactoryPersistsConfigWithBooleanCast(): void
+    {
+        $config = UserMailConfig::factory()->create([
+            'value' => 1,
+        ]);
+
+        $this->assertInstanceOf(UserMailConfig::class, $config);
+        $this->assertIsBool($config->value);
+        $this->assertTrue($config->value);
+    }
+
+    public function testBelongsToUserRelation(): void
+    {
+        $user = User::factory()->create();
+
+        $config = UserMailConfig::factory()
+            ->forUser($user)
+            ->create([
+                'key' => 'daily_summary',
+                'value' => false,
+            ]);
+
+        $this->assertTrue($config->user->is($user));
+        $this->assertSame('daily_summary', $config->key);
+        $this->assertFalse($config->value);
+    }
+}

--- a/tests/Integration/Services/NotificationDiscoveryFacadeTest.php
+++ b/tests/Integration/Services/NotificationDiscoveryFacadeTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Services;
+
+use App\Facades\NotificationDiscovery;
+use App\Notifications\UserUploadDuplicatedNotification;
+use App\Notifications\UserUploadProceedNotification;
+use App\Providers\ServiceServiceProvider;
+use App\Services\Notifications\Decorator\CachedNotificationDiscoveryService;
+use Illuminate\Support\Facades\Cache;
+use Mockery;
+use Tests\TestCase;
+
+final class NotificationDiscoveryFacadeTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    protected function getPackageProviders($app): array
+    {
+        return [
+            ServiceServiceProvider::class,
+        ];
+    }
+
+    public function testFacadeListsNotificationsViaCachedService(): void
+    {
+        Cache::shouldReceive('remember')
+            ->once()
+            ->with('notification_discovery', 3600, Mockery::type('Closure'))
+            ->andReturnUsing(function (string $key, int $ttl, callable $callback) {
+                return $callback();
+            });
+
+        $result = NotificationDiscovery::list();
+
+        $this->assertContains(UserUploadDuplicatedNotification::class, $result);
+        $this->assertContains(UserUploadProceedNotification::class, $result);
+    }
+
+    public function testFacadeResolvesCachedDiscoveryService(): void
+    {
+        $service = NotificationDiscovery::getFacadeRoot();
+
+        $this->assertInstanceOf(CachedNotificationDiscoveryService::class, $service);
+    }
+}


### PR DESCRIPTION
## Summary
- add a model factory and integration coverage for UserMailConfig
- expand User model integration tests and guard the team role pivot against missing team columns
- cover the NotificationDiscovery facade behavior and caching

## Testing
- vendor/bin/phpunit --testsuite Integration --filter UserMailConfigTest --no-coverage
- vendor/bin/phpunit --testsuite Integration --filter UserTest --no-coverage
- vendor/bin/phpunit --testsuite Integration --filter NotificationDiscoveryFacadeTest --no-coverage


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930de53985c8329ac1de9951eb9d9a7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration tests for user mail configuration, team roles relationships, and notification discovery service to improve code reliability.

* **Chores**
  * Enhanced internal model infrastructure with factory support and improved pivot relationship handling for better configuration management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->