### PR TITLE
Refactor MyOffers tabs to Filament v4 schema

### DIFF
--- a/app/Filament/Standard/Pages/MyOffers.php
+++ b/app/Filament/Standard/Pages/MyOffers.php
@@ -278,41 +278,33 @@ class MyOffers extends Page implements HasTable
                     ->limit(50)
                     ->visible(fn(): bool => $this->activeTab === 'returned'),
             ])
-            ->recordActions(function (): array {
-                $commonViewAction = Action::make('view_details')
+            ->recordActions([
+                Action::make('view_details')
                     ->label(__('my_offers.table.actions.view_details'))
                     ->icon('heroicon-m-eye')
                     ->modalHeading(__('my_offers.modal.title'))
                     ->modalWidth(Width::FourExtraLarge)
                     ->schema(fn(Assignment $record): Schema => $this->getDetailsInfolist($record))
                     ->modalSubmitAction(false)
-                    ->modalCancelActionLabel('Schließen');
+                    ->modalCancelActionLabel('Schließen'),
 
-                return match ($this->activeTab) {
-                    'downloaded' => [
-                        $commonViewAction,
-                        Action::make('download_again')
-                            ->label(__('my_offers.table.actions.download_again'))
-                            ->icon('heroicon-m-arrow-path')
-                            ->color('gray')
-                            ->url(fn(Assignment $record): string => '#') // TODO: Implement download URL
-                            ->openUrlInNewTab(),
-                    ],
-                    'available' => [
-                        $commonViewAction,
-                        ViewAction::make('download')
-                            ->label(__('my_offers.table.actions.download'))
-                            ->icon('heroicon-m-arrow-down-tray')
-                            ->color('primary')
-                            ->url(fn(Assignment $record): string => '#') // TODO: Implement download URL
-                            ->openUrlInNewTab(),
-                    ],
-                    default => [
-                        $commonViewAction,
-                    ],
-                };
-            })
-            ->bulkActions(fn() => $this->activeTab === 'available' ? [
+                Action::make('download_again')
+                    ->label(__('my_offers.table.actions.download_again'))
+                    ->icon('heroicon-m-arrow-path')
+                    ->color('gray')
+                    ->url(fn(Assignment $record): string => '#') // TODO: Implement download URL
+                    ->openUrlInNewTab()
+                    ->visible(fn(): bool => $this->activeTab === 'downloaded'),
+
+                ViewAction::make('download')
+                    ->label(__('my_offers.table.actions.download'))
+                    ->icon('heroicon-m-arrow-down-tray')
+                    ->color('primary')
+                    ->url(fn(Assignment $record): string => '#') // TODO: Implement download URL
+                    ->openUrlInNewTab()
+                    ->visible(fn(): bool => $this->activeTab === 'available'),
+            ])
+            ->bulkActions([
                 BulkAction::make('download_selected')
                     ->label(fn(Collection $records): string => __('my_offers.table.bulk_actions.download_selected',
                         ['count' => $records->count()]))
@@ -320,8 +312,9 @@ class MyOffers extends Page implements HasTable
                     ->color('primary')
                     ->action(function (Collection $records) {
                         // TODO: Implement bulk download
-                    }),
-            ] : [])
+                    })
+                    ->visible(fn(): bool => $this->activeTab === 'available'),
+            ])
             ->selectCurrentPageOnly($this->activeTab === 'available')
             ->emptyStateHeading(__('my_offers.table.empty_state.heading'))
             ->emptyStateDescription(match ($this->activeTab) {

--- a/tests/Feature/Standard/Pages/MyOffersTest.php
+++ b/tests/Feature/Standard/Pages/MyOffersTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Standard\Pages;
+
+use App\Enum\Guard\GuardEnum;
+use App\Enum\PanelEnum;
+use App\Enum\Users\RoleEnum;
+use App\Filament\Standard\Pages\MyOffers;
+use App\Models\Channel;
+use App\Models\User;
+use App\Repository\TeamRepository;
+use Filament\Facades\Filament;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Role;
+use Tests\DatabaseTestCase;
+
+final class MyOffersTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('auth.defaults.guard', GuardEnum::STANDARD->value);
+
+        Filament::setCurrentPanel(PanelEnum::STANDARD->value);
+    }
+
+    public function testChannelOperatorCanAccessPage(): void
+    {
+        $user = User::factory()->create();
+        Role::findOrCreate(RoleEnum::CHANNEL_OPERATOR->value, GuardEnum::STANDARD->value);
+        $user->syncRoles([RoleEnum::CHANNEL_OPERATOR->value]);
+
+        $team = app(TeamRepository::class)->createOwnTeamForUser($user);
+
+        $channel = Channel::factory()->create();
+        $channel->channelUsers()->attach($user);
+
+        Filament::setTenant($team, true);
+        Filament::auth()->login($user);
+        $this->actingAs($user, GuardEnum::STANDARD->value);
+
+        Livewire::test(MyOffers::class)
+            ->assertStatus(200);
+    }
+}


### PR DESCRIPTION
## Summary
- adopt Filament v4 schema-driven tabs on the MyOffers page with an explicit default tab
- consolidate table configuration into tab-aware queries and visibility to retain existing semantics
- render the page content through the standard embedded table instead of a custom view

## Testing
- ./vendor/bin/phpunit


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694872e460308329966efa49d82b38f3)