### PR TITLE
Add widget coverage tests for channel stats

### DIFF
--- a/tests/Feature/Filament/Standard/Widgets/ChannelWidgets/AvailableOffersStatsWidgetTest.php
+++ b/tests/Feature/Filament/Standard/Widgets/ChannelWidgets/AvailableOffersStatsWidgetTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament\Standard\Widgets\ChannelWidgets;
+
+use App\Enum\StatusEnum;
+use App\Filament\Standard\Widgets\ChannelWidgets\AvailableOffersStatsWidget;
+use App\Models\Assignment;
+use App\Models\Channel;
+use Carbon\Carbon;
+use Tests\DatabaseTestCase;
+
+final class AvailableOffersStatsWidgetTest extends DatabaseTestCase
+{
+    public function testReturnsZeroStatWhenChannelUnavailable(): void
+    {
+        $widget = new AvailableOffersStatsWidget();
+
+        $stats = $this->callProtectedMethod($widget, 'getStats');
+
+        $this->assertCount(1, $stats);
+        $this->assertSame(0, $stats[0]->getValue());
+        $this->assertNull($stats[0]->getChart());
+    }
+
+    public function testProvidesCountsAndChartDataForChannel(): void
+    {
+        Carbon::setTestNow(Carbon::create(2024, 1, 8, 12));
+
+        $channel = Channel::factory()->create();
+
+        Assignment::factory()->create([
+            'channel_id' => $channel->getKey(),
+            'status' => StatusEnum::QUEUED->value,
+            'expires_at' => now()->addDays(12),
+            'created_at' => now()->subDays(6)->startOfDay(),
+        ]);
+
+        Assignment::factory()->create([
+            'channel_id' => $channel->getKey(),
+            'status' => StatusEnum::NOTIFIED->value,
+            'expires_at' => now()->addDays(2),
+            'created_at' => now()->subDays(2)->startOfDay(),
+        ]);
+
+        Assignment::factory()->create([
+            'channel_id' => $channel->getKey(),
+            'status' => StatusEnum::QUEUED->value,
+            'expires_at' => now()->subDay(),
+            'created_at' => now()->subDays(4)->startOfDay(),
+        ]);
+
+        $widget = new AvailableOffersStatsWidget();
+        $widget->channelId = $channel->getKey();
+
+        $stats = $this->callProtectedMethod($widget, 'getStats');
+        $chartData = $this->callProtectedMethod($widget, 'getAvailableChartData', [$channel]);
+
+        $this->assertCount(1, $stats);
+        $this->assertSame('2', $stats[0]->getValue());
+        $this->assertSame([1, 1, 2, 2, 3, 3, 2], $chartData);
+        $this->assertSame($chartData, $stats[0]->getChart());
+
+        Carbon::setTestNow();
+    }
+
+    private function callProtectedMethod(object $object, string $method, array $parameters = []): mixed
+    {
+        $reflection = new \ReflectionClass($object);
+        $reflectionMethod = $reflection->getMethod($method);
+        $reflectionMethod->setAccessible(true);
+
+        return $reflectionMethod->invokeArgs($object, $parameters);
+    }
+}

--- a/tests/Feature/Filament/Standard/Widgets/ChannelWidgets/BaseChannelWidgetTest.php
+++ b/tests/Feature/Filament/Standard/Widgets/ChannelWidgets/BaseChannelWidgetTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament\Standard\Widgets\ChannelWidgets;
+
+use App\Filament\Standard\Widgets\ChannelWidgets\AvailableOffersStatsWidget;
+use App\Models\Channel;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+use Tests\DatabaseTestCase;
+
+final class BaseChannelWidgetTest extends DatabaseTestCase
+{
+    public function testMountStoresProvidedChannelId(): void
+    {
+        $channel = Channel::factory()->create();
+        $widget = new AvailableOffersStatsWidget();
+
+        $widget->mount($channel->getKey());
+
+        $this->assertSame($channel->getKey(), $widget->channelId);
+    }
+
+    public function testGetChannelUsesInjectedIdentifier(): void
+    {
+        $channel = Channel::factory()->create();
+        $widget = new AvailableOffersStatsWidget();
+        $widget->channelId = $channel->getKey();
+
+        $resolvedChannel = $this->callProtectedMethod($widget, 'getChannel');
+
+        $this->assertNotNull($resolvedChannel);
+        $this->assertTrue($channel->is($resolvedChannel));
+    }
+
+    public function testGetChannelFallsBackToLatestUserChannel(): void
+    {
+        $user = User::factory()->create();
+        $earlierChannel = Channel::factory()->create(['created_at' => now()->subDay()]);
+        $latestChannel = Channel::factory()->create();
+        $user->channels()->attach($earlierChannel);
+        $user->channels()->attach($latestChannel);
+        Auth::login($user);
+
+        $widget = new AvailableOffersStatsWidget();
+
+        $resolvedChannel = $this->callProtectedMethod($widget, 'getChannel');
+
+        $this->assertNotNull($resolvedChannel);
+        $this->assertTrue($latestChannel->is($resolvedChannel));
+    }
+
+    private function callProtectedMethod(object $object, string $method, array $parameters = []): mixed
+    {
+        $reflection = new \ReflectionClass($object);
+        $reflectionMethod = $reflection->getMethod($method);
+        $reflectionMethod->setAccessible(true);
+
+        return $reflectionMethod->invokeArgs($object, $parameters);
+    }
+}

--- a/tests/Feature/Filament/Standard/Widgets/ChannelWidgets/DownloadedOffersStatsWidgetTest.php
+++ b/tests/Feature/Filament/Standard/Widgets/ChannelWidgets/DownloadedOffersStatsWidgetTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament\Standard\Widgets\ChannelWidgets;
+
+use App\Enum\StatusEnum;
+use App\Filament\Standard\Widgets\ChannelWidgets\DownloadedOffersStatsWidget;
+use App\Models\Assignment;
+use App\Models\Channel;
+use App\Models\Download;
+use Carbon\Carbon;
+use Tests\DatabaseTestCase;
+
+final class DownloadedOffersStatsWidgetTest extends DatabaseTestCase
+{
+    public function testReturnsZeroStatsWhenChannelUnavailable(): void
+    {
+        $widget = new DownloadedOffersStatsWidget();
+
+        $stats = $this->callProtectedMethod($widget, 'getStats');
+
+        $this->assertCount(3, $stats);
+        $this->assertSame(0, $stats[0]->getValue());
+        $this->assertSame(0, $stats[1]->getValue());
+        $this->assertSame(0, $stats[2]->getValue());
+    }
+
+    public function testComputesDownloadStatistics(): void
+    {
+        $now = now();
+
+        $channel = Channel::factory()->create();
+
+        $assignmentToday = Assignment::factory()->create([
+            'channel_id' => $channel->getKey(),
+            'status' => StatusEnum::PICKEDUP->value,
+            'created_at' => $now,
+        ]);
+
+        $assignmentThisWeek = Assignment::factory()->create([
+            'channel_id' => $channel->getKey(),
+            'status' => StatusEnum::PICKEDUP->value,
+            'created_at' => $now->copy()->subDays(3),
+        ]);
+
+        $assignmentOld = Assignment::factory()->create([
+            'channel_id' => $channel->getKey(),
+            'status' => StatusEnum::PICKEDUP->value,
+            'created_at' => $now->copy()->subDays(6),
+        ]);
+
+        $recentDownload = $now;
+        $yesterdayDownload = $now->copy()->subDay();
+        $olderDownload = $now->copy()->subDays(5);
+
+        Download::factory()->forAssignment($assignmentToday)->at($recentDownload)->create();
+        Download::factory()->forAssignment($assignmentThisWeek)->at($yesterdayDownload)->create();
+        Download::factory()->forAssignment($assignmentOld)->at($olderDownload)->create();
+
+        $widget = new DownloadedOffersStatsWidget();
+        $widget->channelId = $channel->getKey();
+
+        $stats = $this->callProtectedMethod($widget, 'getStats');
+        $chartData = $this->callProtectedMethod($widget, 'getDownloadedChartData', [$channel]);
+
+        $expectedChart = [];
+        for ($i = 6; $i >= 0; $i--) {
+            $date = $now->copy()->subDays($i)->toDateString();
+            $expectedChart[] = collect([
+                $recentDownload,
+                $yesterdayDownload,
+                $olderDownload,
+            ])->filter(fn(Carbon $downloadDate) => $downloadDate->toDateString() === $date)->count();
+        }
+
+        $this->assertSame('3', $stats[0]->getValue());
+        $weeklyCount = collect([$recentDownload, $yesterdayDownload])
+            ->filter(fn(Carbon $downloadDate) => $downloadDate->greaterThanOrEqualTo($now->copy()->startOfWeek()))
+            ->count();
+
+        $this->assertSame((string)$weeklyCount, $stats[1]->getValue());
+        $averageDaysQuery = Assignment::query()
+            ->where('channel_id', $channel->getKey())
+            ->where('status', StatusEnum::PICKEDUP->value)
+            ->whereHas('downloads')
+            ->join('downloads', 'assignments.id', '=', 'downloads.assignment_id');
+
+        $calculatedAverage = (float)$averageDaysQuery
+            ->selectRaw("AVG((strftime('%s', 'now') - strftime('%s', downloads.downloaded_at)) / 86400) as avg_days_ago")
+            ->value('avg_days_ago');
+
+        $this->assertSame((string)(int)round($calculatedAverage ?: 0.0), $stats[2]->getValue());
+        $this->assertSame($expectedChart, $chartData);
+        $this->assertSame($chartData, $stats[0]->getChart());
+    }
+
+    private function callProtectedMethod(object $object, string $method, array $parameters = []): mixed
+    {
+        $reflection = new \ReflectionClass($object);
+        $reflectionMethod = $reflection->getMethod($method);
+        $reflectionMethod->setAccessible(true);
+
+        return $reflectionMethod->invokeArgs($object, $parameters);
+    }
+}

--- a/tests/Feature/Filament/Standard/Widgets/ChannelWidgets/ExpiredOffersStatsWidgetTest.php
+++ b/tests/Feature/Filament/Standard/Widgets/ChannelWidgets/ExpiredOffersStatsWidgetTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament\Standard\Widgets\ChannelWidgets;
+
+use App\Enum\StatusEnum;
+use App\Filament\Standard\Widgets\ChannelWidgets\ExpiredOffersStatsWidget;
+use App\Models\Assignment;
+use App\Models\Channel;
+use Carbon\Carbon;
+use Tests\DatabaseTestCase;
+
+final class ExpiredOffersStatsWidgetTest extends DatabaseTestCase
+{
+    public function testReturnsZeroStatsWhenChannelUnavailable(): void
+    {
+        $widget = new ExpiredOffersStatsWidget();
+
+        $stats = $this->callProtectedMethod($widget, 'getStats');
+
+        $this->assertCount(3, $stats);
+        $this->assertSame(0, $stats[0]->getValue());
+        $this->assertSame(0, $stats[1]->getValue());
+        $this->assertSame(0, $stats[2]->getValue());
+    }
+
+    public function testComputesExpiredOfferStatistics(): void
+    {
+        Carbon::setTestNow(Carbon::create(2024, 1, 8, 12));
+
+        $channel = Channel::factory()->create();
+
+        $expiredToday = Assignment::factory()->create([
+            'channel_id' => $channel->getKey(),
+            'status' => StatusEnum::EXPIRED->value,
+            'updated_at' => now(),
+        ]);
+
+        $expiredWithDownload = Assignment::factory()->create([
+            'channel_id' => $channel->getKey(),
+            'status' => StatusEnum::EXPIRED->value,
+            'updated_at' => now()->subDays(3),
+        ]);
+        $expiredWithDownload->downloads()->create([
+            'downloaded_at' => now()->subDays(3),
+            'ip' => '127.0.0.1',
+            'user_agent' => 'test-agent',
+            'bytes_sent' => 1,
+        ]);
+
+        Assignment::factory()->create([
+            'channel_id' => $channel->getKey(),
+            'status' => StatusEnum::EXPIRED->value,
+            'updated_at' => now()->subDays(6),
+        ]);
+
+        $widget = new ExpiredOffersStatsWidget();
+        $widget->channelId = $channel->getKey();
+
+        $stats = $this->callProtectedMethod($widget, 'getStats');
+        $chartData = $this->callProtectedMethod($widget, 'getExpiredChartData', [$channel]);
+
+        $this->assertSame('3', $stats[0]->getValue());
+        $this->assertSame('1', $stats[1]->getValue());
+        $this->assertSame('2', $stats[2]->getValue());
+        $this->assertSame([1, 0, 0, 1, 0, 0, 1], $chartData);
+        $this->assertSame($chartData, $stats[0]->getChart());
+
+        Carbon::setTestNow();
+    }
+
+    private function callProtectedMethod(object $object, string $method, array $parameters = []): mixed
+    {
+        $reflection = new \ReflectionClass($object);
+        $reflectionMethod = $reflection->getMethod($method);
+        $reflectionMethod->setAccessible(true);
+
+        return $reflectionMethod->invokeArgs($object, $parameters);
+    }
+}


### PR DESCRIPTION
## Summary
- add feature tests covering channel widget behaviours and fallback logic
- verify stats and chart data for available, downloaded, and expired offer widgets
- ensure base widget channel resolution is exercised for provided and fallback channels

## Testing
- ./vendor/bin/phpunit --no-coverage tests/Feature/Filament/Standard/Widgets/ChannelWidgets


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cfd1b25688329b62a026ec6953b68)