### PR TITLE
Expand CleanUpDatabase command coverage

### DIFF
--- a/app/Application/Cleanup/CleanupDatabase.php
+++ b/app/Application/Cleanup/CleanupDatabase.php
@@ -6,7 +6,7 @@ namespace App\Application\Cleanup;
 
 use App\Repository\ActionTokenRepository;
 
-final readonly class CleanupDatabase
+class CleanupDatabase
 {
     public function __construct(private ActionTokenRepository $actionTokenRepository)
     {

--- a/tests/Feature/Console/Commands/CleanUpDatabaseCommandTest.php
+++ b/tests/Feature/Console/Commands/CleanUpDatabaseCommandTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console\Commands;
+
+use App\Application\Cleanup\CleanupDatabase;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+final class CleanUpDatabaseCommandTest extends TestCase
+{
+    public function testRunsCleanupServiceSuccessfully(): void
+    {
+        $this->mock(CleanupDatabase::class)
+            ->expects('handle')
+            ->once()
+            ->andReturnNull();
+
+        Log::spy();
+
+        $this->artisan('clean:database')
+            ->assertExitCode(Command::SUCCESS);
+
+        Log::shouldNotHaveReceived('error');
+    }
+
+    public function testLogsErrorAndReturnsFailureOnException(): void
+    {
+        $exception = new \RuntimeException('test exception');
+
+        $this->mock(CleanupDatabase::class)
+            ->expects('handle')
+            ->once()
+            ->andThrow($exception);
+
+        Log::spy();
+
+        $this->artisan('clean:database')
+            ->assertExitCode(Command::FAILURE);
+
+        Log::shouldHaveReceived('error')
+            ->once()
+            ->with(
+                'Error during database cleanup: ' . $exception->getMessage(),
+                [
+                    'exception' => $exception,
+                ]
+            );
+    }
+
+    public function testLogsErrorAndReturnsFailureOnThrowable(): void
+    {
+        $throwable = new \Error('unexpected error');
+
+        $this->mock(CleanupDatabase::class)
+            ->expects('handle')
+            ->once()
+            ->andThrow($throwable);
+
+        Log::spy();
+
+        $this->artisan('clean:database')
+            ->assertExitCode(Command::FAILURE);
+
+        Log::shouldHaveReceived('error')
+            ->once()
+            ->with(
+                'Error during database cleanup: ' . $throwable->getMessage(),
+                [
+                    'exception' => $throwable,
+                ]
+            );
+    }
+}


### PR DESCRIPTION
## Summary
- allow the database cleanup service to be mocked by removing the `readonly` final restriction
- expand `CleanUpDatabaseCommand` feature coverage to assert handling of successful runs and throwable failures

## Testing
- composer install
- ./vendor/bin/phpunit --no-coverage
- ./vendor/bin/phpunit --no-coverage --filter CleanUpDatabaseCommandTest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fe03a8cb08329be005511e6a1f83e)