### PR TITLE
Fix channel email owner operator check

### DIFF
--- a/app/Services/Channel/ChannelOperatorService.php
+++ b/app/Services/Channel/ChannelOperatorService.php
@@ -131,6 +131,6 @@ readonly class ChannelOperatorService
             return false;
         }
 
-        return $this->isUserChannelOperator($owner, $channel);
+        return $this->isUserChannelOperator($user, $channel);
     }
 }

--- a/tests/Integration/Services/Channel/ChannelOperatorServiceTest.php
+++ b/tests/Integration/Services/Channel/ChannelOperatorServiceTest.php
@@ -8,6 +8,7 @@ use App\Enum\Guard\GuardEnum;
 use App\Enum\Users\RoleEnum;
 use App\Models\Channel;
 use App\Models\User;
+use App\Repository\ChannelRepository;
 use App\Repository\RoleRepository;
 use App\Services\Channel\ChannelOperatorService;
 use Tests\DatabaseTestCase;
@@ -112,6 +113,147 @@ final class ChannelOperatorServiceTest extends DatabaseTestCase
                 RoleEnum::CHANNEL_OPERATOR->value,
                 GuardEnum::STANDARD->value
             )
+        );
+    }
+
+    public function testApproveUserChannelAccessThrowsExceptionWhenUserLacksAccess(): void
+    {
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('User does not have access to the channel.');
+
+        $user = User::factory()->create();
+        $channel = Channel::factory()->create();
+
+        $this->service->approveUserChannelAccess($user, $channel);
+    }
+
+    public function testApproveUserChannelAccessMarksUserVerified(): void
+    {
+        $user = User::factory()->create();
+        $channel = Channel::factory()->create();
+        $channelRepository = $this->app->make(ChannelRepository::class);
+
+        $channelRepository->assignUserToChannel($user, $channel);
+
+        $this->service->approveUserChannelAccess($user, $channel);
+
+        $this->assertTrue(
+            $channelRepository->isUserVerifiedForChannel($user, $channel)
+        );
+    }
+
+    public function testRevokeUserChannelAccessRemovesRoleWhenNoChannelsLeft(): void
+    {
+        $user = User::factory()->create();
+        $channel = Channel::factory()->create();
+        $channelRepository = $this->app->make(ChannelRepository::class);
+        $roleRepository = $this->app->make(RoleRepository::class);
+
+        $this->service->addUserToChannel($user, $channel);
+        $channelRepository->setUserVerifiedForChannel($user, $channel);
+
+        $this->service->revokeUserChannelAccess($user, $channel);
+
+        $this->assertFalse(
+            $channelRepository->hasUserAccessToChannel($user, $channel)
+        );
+        $this->assertFalse(
+            $roleRepository->hasRole($user, RoleEnum::CHANNEL_OPERATOR, GuardEnum::STANDARD)
+        );
+    }
+
+    public function testRevokeUserChannelAccessKeepsRoleWithOtherVerifiedChannels(): void
+    {
+        $user = User::factory()->create();
+        $primaryChannel = Channel::factory()->create();
+        $secondaryChannel = Channel::factory()->create();
+        $channelRepository = $this->app->make(ChannelRepository::class);
+        $roleRepository = $this->app->make(RoleRepository::class);
+
+        $this->service->addUserToChannel($user, $primaryChannel);
+        $this->service->addUserToChannel($user, $secondaryChannel);
+
+        $channelRepository->setUserVerifiedForChannel($user, $primaryChannel);
+        $channelRepository->setUserVerifiedForChannel($user, $secondaryChannel);
+
+        $this->service->revokeUserChannelAccess($user, $secondaryChannel);
+
+        $this->assertFalse(
+            $channelRepository->hasUserAccessToChannel($user, $secondaryChannel)
+        );
+        $this->assertTrue(
+            $channelRepository->hasUserAccessToChannel($user, $primaryChannel)
+        );
+        $this->assertTrue(
+            $roleRepository->hasRole($user, RoleEnum::CHANNEL_OPERATOR, GuardEnum::STANDARD)
+        );
+    }
+
+    public function testIsUserChannelOperatorRequiresVerification(): void
+    {
+        $user = User::factory()->create();
+        $channel = Channel::factory()->create();
+        $channelRepository = $this->app->make(ChannelRepository::class);
+
+        $this->service->addUserToChannel($user, $channel);
+
+        $this->assertFalse(
+            $this->service->isUserChannelOperator($user, $channel)
+        );
+
+        $channelRepository->setUserVerifiedForChannel($user, $channel);
+
+        $this->assertTrue(
+            $this->service->isUserChannelOperator($user, $channel)
+        );
+    }
+
+    public function testIsUserChannelOperatorRequiresRole(): void
+    {
+        $user = User::factory()->create();
+        $channel = Channel::factory()->create();
+        $channelRepository = $this->app->make(ChannelRepository::class);
+        $roleRepository = $this->app->make(RoleRepository::class);
+
+        $this->service->addUserToChannel($user, $channel);
+        $channelRepository->setUserVerifiedForChannel($user, $channel);
+        $roleRepository->removeRoleFromUser($user, RoleEnum::CHANNEL_OPERATOR, GuardEnum::STANDARD);
+
+        $this->assertFalse(
+            $this->service->isUserChannelOperator($user, $channel)
+        );
+    }
+
+    public function testIsChannelEmailOwnerChannelOperatorReturnsFalseWithoutMatchingUser(): void
+    {
+        $channel = Channel::factory()->create(['email' => 'missing@example.com']);
+
+        $this->assertFalse(
+            $this->service->isChannelEmailOwnerChannelOperator($channel)
+        );
+    }
+
+    public function testIsChannelEmailOwnerChannelOperatorReturnsFalseWhenUserIsNotOperator(): void
+    {
+        $user = User::factory()->create(['email' => 'owner@example.com']);
+        $channel = Channel::factory()->create(['email' => $user->email]);
+
+        $this->assertFalse(
+            $this->service->isChannelEmailOwnerChannelOperator($channel)
+        );
+    }
+
+    public function testIsChannelEmailOwnerChannelOperatorReturnsTrueWhenUserIsVerifiedOperator(): void
+    {
+        $user = User::factory()->create(['email' => 'owner@example.com']);
+        $channel = Channel::factory()->create(['email' => $user->email]);
+        $channelRepository = $this->app->make(ChannelRepository::class);
+
+        $this->service->addUserToChannel($user, $channel);
+        $channelRepository->setUserVerifiedForChannel($user, $channel);
+
+        $this->assertTrue(
+            $this->service->isChannelEmailOwnerChannelOperator($channel)
         );
     }
 }


### PR DESCRIPTION
## Summary
- fix channel email owner operator check to use the resolved user instead of the raw email
- adjust channel operator integration tests to cover missing users, non-operators, and verified operators

## Testing
- composer install --no-interaction
- php -d memory_limit=512M ./vendor/bin/phpunit --no-coverage


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fdfe07f2c8329af9762aead1fee33)