### PR TITLE
Add feature tests for Filament user resource pages

### DIFF
--- a/tests/Feature/Filament/Resources/UserResource/Pages/CreateUserTest.php
+++ b/tests/Feature/Filament/Resources/UserResource/Pages/CreateUserTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament\Resources\UserResource\Pages;
+
+use App\Enum\Users\RoleEnum;
+use App\Events\User\UserCreated;
+use App\Filament\Resources\UserResource\Pages\CreateUser;
+use App\Models\User;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Hash;
+use Livewire\Livewire;
+use Tests\DatabaseTestCase;
+
+final class CreateUserTest extends DatabaseTestCase
+{
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->admin()->create();
+        $this->actingAs($this->admin, 'web');
+    }
+
+    public function testCreatesUserWithGeneratedPasswordAndDefaultRole(): void
+    {
+        Event::fake([UserCreated::class]);
+
+        Livewire::test(CreateUser::class)
+            ->assertStatus(200)
+            ->fillForm([
+                'name' => 'Generated User',
+                'email' => 'generated@example.com',
+                'password' => '',
+                'roles' => [],
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        $user = User::query()->where('email', 'generated@example.com')->first();
+
+        $this->assertNotNull($user);
+        $this->assertTrue($user->hasRole(RoleEnum::REGULAR->value));
+
+        Event::assertDispatched(UserCreated::class, function (UserCreated $event) use ($user): bool {
+            return $event->user->is($user)
+                && $event->fromBackend === true
+                && is_string($event->plainPassword)
+                && $event->plainPassword !== '';
+        });
+    }
+
+    public function testCreatesUserWithProvidedPassword(): void
+    {
+        Event::fake([UserCreated::class]);
+
+        $password = 'Secure123!';
+
+        Livewire::test(CreateUser::class)
+            ->fillForm([
+                'name' => 'Custom Password',
+                'email' => 'custom@example.com',
+                'password' => $password,
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        $user = User::query()->where('email', 'custom@example.com')->first();
+
+        $this->assertNotNull($user);
+        $this->assertTrue(Hash::check($password, $user->password));
+
+        Event::assertDispatched(UserCreated::class, function (UserCreated $event) use ($user, $password): bool {
+            return $event->user->is($user)
+                && $event->plainPassword === $password
+                && $event->fromBackend === true;
+        });
+    }
+}

--- a/tests/Feature/Filament/Resources/UserResource/Pages/EditUserTest.php
+++ b/tests/Feature/Filament/Resources/UserResource/Pages/EditUserTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament\Resources\UserResource\Pages;
+
+use App\Filament\Resources\UserResource\Pages\EditUser;
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use Livewire\Livewire;
+use Tests\DatabaseTestCase;
+
+final class EditUserTest extends DatabaseTestCase
+{
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->admin()->create();
+        $this->actingAs($this->admin, 'web');
+    }
+
+    public function testUpdatingWithoutPasswordKeepsExistingHash(): void
+    {
+        $user = User::factory()->create([
+            'password' => Hash::make('original-password'),
+        ]);
+
+        Livewire::test(EditUser::class, ['record' => $user->getKey()])
+            ->assertStatus(200)
+            ->fillForm([
+                'name' => 'Updated Name',
+                'email' => $user->email,
+                'password' => '',
+            ])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $user->refresh();
+
+        $this->assertSame('Updated Name', $user->name);
+        $this->assertTrue(Hash::check('original-password', $user->password));
+    }
+
+    public function testUpdatingWithPasswordRehashesValue(): void
+    {
+        $user = User::factory()->create([
+            'password' => Hash::make('original-password'),
+        ]);
+
+        Livewire::test(EditUser::class, ['record' => $user->getKey()])
+            ->fillForm([
+                'name' => $user->name,
+                'email' => $user->email,
+                'password' => 'new-password-123',
+            ])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $user->refresh();
+
+        $this->assertTrue(Hash::check('new-password-123', $user->password));
+    }
+
+    public function testEditUserPageShowsDeleteAction(): void
+    {
+        $user = User::factory()->create();
+
+        Livewire::test(EditUser::class, ['record' => $user->getKey()])
+            ->assertStatus(200)
+            ->assertActionVisible('delete');
+    }
+}

--- a/tests/Feature/Filament/Resources/UserResource/Pages/ListUsersTest.php
+++ b/tests/Feature/Filament/Resources/UserResource/Pages/ListUsersTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament\Resources\UserResource\Pages;
+
+use App\Filament\Resources\UserResource\Pages\ListUsers;
+use App\Models\User;
+use Livewire\Livewire;
+use Tests\DatabaseTestCase;
+
+final class ListUsersTest extends DatabaseTestCase
+{
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->admin()->create();
+        $this->actingAs($this->admin, 'web');
+    }
+
+    public function testListUsersHeaderShowsCreateAction(): void
+    {
+        Livewire::test(ListUsers::class)
+            ->assertStatus(200)
+            ->assertActionVisible('create');
+    }
+
+    public function testListUsersShowsRecordActions(): void
+    {
+        $user = User::factory()->create();
+
+        Livewire::test(ListUsers::class)
+            ->assertStatus(200)
+            ->assertTableActionVisible('edit', $user)
+            ->assertTableActionVisible('resetPassword', $user);
+    }
+}

--- a/tests/Feature/Filament/Resources/UserResourceTest.php
+++ b/tests/Feature/Filament/Resources/UserResourceTest.php
@@ -82,6 +82,14 @@ final class UserResourceTest extends DatabaseTestCase
         $this->assertSame((string)User::count(), $badge);
     }
 
+    public function testSuperAdminCanAccessResource(): void
+    {
+        $this->actingAs($this->admin);
+
+        $this->assertTrue(UserResource::canAccess());
+        $this->assertTrue(UserResource::shouldRegisterNavigation());
+    }
+
     public function testRegularUserCannotAccessResource(): void
     {
         $user = User::factory()->standard()->create();
@@ -89,5 +97,13 @@ final class UserResourceTest extends DatabaseTestCase
 
         $this->assertFalse(UserResource::canAccess());
         $this->assertFalse(UserResource::shouldRegisterNavigation());
+    }
+
+    public function testNavigationBadgeHiddenForNonSuperAdmin(): void
+    {
+        $user = User::factory()->standard()->create();
+        $this->actingAs($user);
+
+        $this->assertNull(UserResource::getNavigationBadge());
     }
 }


### PR DESCRIPTION
## Summary
- add Create, Edit, and List page feature tests for the Filament UserResource
- verify password handling, default role assignment, and table actions through Livewire assertions
- extend resource coverage for access rules and navigation badge visibility

## Testing
- composer install
- php -d memory_limit=1G ./vendor/bin/phpunit --no-coverage *(fails: ffmpeg binary missing for preview generation tests)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69500be399208329976ced2ca12a162d)