### PR TITLE
Add channel application Filament feature tests

### DIFF
--- a/tests/Feature/Filament/Resources/ChannelApplicationResource/ChannelApplicationResourceTest.php
+++ b/tests/Feature/Filament/Resources/ChannelApplicationResource/ChannelApplicationResourceTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament\Resources\ChannelApplicationResource;
+
+use App\Enum\Channel\ApplicationEnum;
+use App\Filament\Resources\ChannelApplicationResource;
+use App\Filament\Resources\ChannelApplicationResource\Pages\EditChannelApplication;
+use App\Filament\Resources\ChannelApplicationResource\Pages\ListChannelApplications;
+use App\Models\Channel;
+use App\Models\ChannelApplication;
+use App\Models\User;
+use Filament\Resources\Pages\PageRegistration;
+use Livewire\Livewire;
+use Tests\DatabaseTestCase;
+
+final class ChannelApplicationResourceTest extends DatabaseTestCase
+{
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->admin()->create();
+        $this->actingAs($this->admin);
+    }
+
+    public function testResourceCannotCreateRecords(): void
+    {
+        $this->assertFalse(ChannelApplicationResource::canCreate());
+    }
+
+    public function testResourceRegistersExpectedPages(): void
+    {
+        $pages = ChannelApplicationResource::getPages();
+
+        $this->assertSame(['index', 'edit'], array_keys($pages));
+        $this->assertContainsOnlyInstancesOf(PageRegistration::class, $pages);
+        $this->assertSame(ListChannelApplications::class, $pages['index']->getPage());
+        $this->assertSame(EditChannelApplication::class, $pages['edit']->getPage());
+    }
+
+    public function testTableShowsApplicationsWithApplicantAndStatus(): void
+    {
+        $applicant = User::factory()->create(['name' => 'Applicant User']);
+        $channel = Channel::factory()->create(['name' => 'Existing Channel']);
+
+        $pending = ChannelApplication::factory()
+            ->for($applicant)
+            ->forExistingChannel($channel)
+            ->withStatus(ApplicationEnum::PENDING)
+            ->create();
+
+        $approved = ChannelApplication::factory()
+            ->for($applicant)
+            ->forExistingChannel($channel)
+            ->withStatus(ApplicationEnum::APPROVED)
+            ->create();
+
+        Livewire::test(ListChannelApplications::class)
+            ->assertStatus(200)
+            ->assertCanSeeTableRecords([$pending])
+            ->assertCanNotSeeTableRecords([$approved])
+            ->assertTableColumnStateSet('user.name', $applicant->name, record: $pending)
+            ->assertTableColumnStateSet('channel.name', $channel->name, record: $pending)
+            ->assertTableColumnStateSet('status', ApplicationEnum::PENDING->value, record: $pending)
+            ->assertTableColumnExists('created_at', record: $pending)
+            ->assertTableColumnExists('updated_at', record: $pending);
+    }
+}

--- a/tests/Feature/Filament/Resources/ChannelApplicationResource/Pages/EditChannelApplicationTest.php
+++ b/tests/Feature/Filament/Resources/ChannelApplicationResource/Pages/EditChannelApplicationTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament\Resources\ChannelApplicationResource\Pages;
+
+use App\Enum\Channel\ApplicationEnum;
+use App\Filament\Resources\ChannelApplicationResource\Pages\EditChannelApplication;
+use App\Models\ChannelApplication;
+use App\Models\User;
+use Illuminate\Support\Facades\Notification as NotificationFacade;
+use Livewire\Livewire;
+use Tests\DatabaseTestCase;
+
+final class EditChannelApplicationTest extends DatabaseTestCase
+{
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->admin()->create();
+        $this->actingAs($this->admin);
+    }
+
+    public function testEditFormLoadsRecordAndUpdatesMeta(): void
+    {
+        $application = ChannelApplication::factory()
+            ->withMeta([
+                'new_channel' => [
+                    'name' => 'Original Name',
+                    'creator_name' => 'Creator',
+                    'email' => 'original@example.com',
+                    'youtube_name' => 'channel-handle',
+                ],
+                'reject_reason' => 'Old reason',
+            ])
+            ->create([
+                'note' => 'Original note',
+            ]);
+
+        Livewire::test(EditChannelApplication::class, ['record' => $application->getKey()])
+            ->assertStatus(200)
+            ->assertFormSet([
+                'user_id' => $application->user_id,
+                'status' => ApplicationEnum::PENDING->value,
+                'meta' => [
+                    'new_channel' => [
+                        'name' => 'Original Name',
+                        'creator_name' => 'Creator',
+                        'email' => 'original@example.com',
+                        'youtube_name' => 'channel-handle',
+                    ],
+                    'reject_reason' => 'Old reason',
+                    'tos_accepted' => false,
+                    'tos_accepted_at' => null,
+                ],
+                'note' => 'Original note',
+            ])
+            ->fillForm([
+                'meta.reject_reason' => 'Updated reason',
+            ])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $application->refresh();
+
+        $meta = $application->meta->toArray();
+        $this->assertSame('Original Name', $meta['new_channel']['name']);
+        $this->assertSame('Creator', $meta['new_channel']['creator_name']);
+        $this->assertSame('original@example.com', $meta['new_channel']['email']);
+        $this->assertSame('channel-handle', $meta['new_channel']['youtube_name']);
+        $this->assertSame('Updated reason', $meta['reject_reason']);
+        $this->assertSame('Original note', $application->note);
+    }
+
+    public function testAfterSaveApprovesApplicationWhenStatusIsApproved(): void
+    {
+        $application = ChannelApplication::factory()->create([
+            'status' => ApplicationEnum::PENDING->value,
+        ]);
+
+        $approve = new class($application, $this->admin) {
+            public bool $called = false;
+
+            public function __construct(
+                private ChannelApplication $expectedRecord,
+                private User $expectedUser,
+            ) {
+            }
+
+            public function handle(ChannelApplication $record, User $user): void
+            {
+                $this->called = $record->is($this->expectedRecord) && $user->is($this->expectedUser);
+            }
+        };
+
+        $this->app->instance(\App\Application\Channel\Application\ApproveChannelApplication::class, $approve);
+
+        Livewire::test(EditChannelApplication::class, ['record' => $application->getKey()])
+            ->fillForm([
+                'status' => ApplicationEnum::APPROVED->value,
+            ])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $this->assertTrue($approve->called);
+    }
+
+    public function testAfterSaveSilentlyHandlesApprovalErrors(): void
+    {
+        $application = ChannelApplication::factory()->create([
+            'status' => ApplicationEnum::PENDING->value,
+        ]);
+
+        NotificationFacade::fake();
+
+        $approve = new class() {
+            public bool $called = false;
+
+            public function handle(ChannelApplication $record, ?User $user = null): void
+            {
+                $this->called = true;
+                throw new \RuntimeException('Something went wrong');
+            }
+        };
+
+        $this->app->instance(\App\Application\Channel\Application\ApproveChannelApplication::class, $approve);
+
+        Livewire::test(EditChannelApplication::class, ['record' => $application->getKey()])
+            ->fillForm([
+                'status' => ApplicationEnum::APPROVED->value,
+            ])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $this->assertTrue(true, 'Approval exception was handled without breaking the page.');
+        $this->assertTrue($approve->called);
+    }
+
+    public function testAfterSaveDoesNothingWhenNotApproved(): void
+    {
+        $application = ChannelApplication::factory()->create([
+            'status' => ApplicationEnum::PENDING->value,
+        ]);
+
+        $approve = new class() {
+            public bool $called = false;
+
+            public function handle(ChannelApplication $record, ?User $user = null): void
+            {
+                $this->called = true;
+            }
+        };
+
+        $this->app->instance(\App\Application\Channel\Application\ApproveChannelApplication::class, $approve);
+
+        Livewire::test(EditChannelApplication::class, ['record' => $application->getKey()])
+            ->fillForm([
+                'status' => ApplicationEnum::REJECTED->value,
+            ])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $this->assertFalse($approve->called);
+    }
+}

--- a/tests/Feature/Filament/Resources/ChannelApplicationResource/Pages/ListChannelApplicationsTest.php
+++ b/tests/Feature/Filament/Resources/ChannelApplicationResource/Pages/ListChannelApplicationsTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament\Resources\ChannelApplicationResource\Pages;
+
+use App\Enum\Channel\ApplicationEnum;
+use App\Filament\Resources\ChannelApplicationResource\Pages\ListChannelApplications;
+use App\Models\Channel;
+use App\Models\ChannelApplication;
+use App\Models\User;
+use Livewire\Livewire;
+use Tests\DatabaseTestCase;
+
+final class ListChannelApplicationsTest extends DatabaseTestCase
+{
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->admin()->create();
+        $this->actingAs($this->admin);
+    }
+
+    public function testListShowsPendingApplicationsByDefault(): void
+    {
+        $channel = Channel::factory()->create(['name' => 'Filament Channel']);
+        $pending = ChannelApplication::factory()
+            ->forExistingChannel($channel)
+            ->withStatus(ApplicationEnum::PENDING)
+            ->create();
+
+        $approved = ChannelApplication::factory()
+            ->forExistingChannel($channel)
+            ->withStatus(ApplicationEnum::APPROVED)
+            ->create();
+
+        Livewire::test(ListChannelApplications::class)
+            ->assertStatus(200)
+            ->assertCanSeeTableRecords([$pending])
+            ->assertCanNotSeeTableRecords([$approved]);
+    }
+
+    public function testListDisplaysColumnData(): void
+    {
+        $applicant = User::factory()->create(['name' => 'Applicant A']);
+        $channel = Channel::factory()->create(['name' => 'Primary Channel']);
+
+        $application = ChannelApplication::factory()
+            ->for($applicant)
+            ->forExistingChannel($channel)
+            ->withStatus(ApplicationEnum::PENDING)
+            ->create();
+
+        Livewire::test(ListChannelApplications::class)
+            ->assertStatus(200)
+            ->assertCanSeeTableRecords([$application]);
+    }
+}


### PR DESCRIPTION
## Summary
- add feature coverage for ChannelApplicationResource registration and table output
- add list page tests covering default filters and visibility
- add edit page tests for metadata persistence and approval handling flows

## Testing
- php -d memory_limit=1G ./vendor/bin/phpunit --no-coverage --filter ChannelApplicationResource
- php -d memory_limit=1G ./vendor/bin/phpunit --no-coverage --filter ProcessUploadedVideoTest *(fails: missing ffmpeg executable)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69500bb4c1408329bdab0ef37707e896)