### PR TITLE
Add integration tests for Filament traits

### DIFF
--- a/tests/Integration/Filament/Traits/ChannelOwnerContextTraitTest.php
+++ b/tests/Integration/Filament/Traits/ChannelOwnerContextTraitTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Filament\Traits;
+
+use App\Application\Channel\GetCurrentChannel;
+use App\Enum\Users\RoleEnum;
+use App\Filament\Traits\ChannelOwnerContextTrait;
+use App\Models\Channel;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Gate;
+use Tests\DatabaseTestCase;
+
+final class ChannelOwnerContextTraitTest extends DatabaseTestCase
+{
+    private function createTraitInstance(): object
+    {
+        return new class () {
+            use ChannelOwnerContextTrait {
+                getCurrentChannel as public getCurrentChannelPublic;
+                getCurrentChannelOnlyIfHaveAccess as public getCurrentChannelOnlyIfHaveAccessPublic;
+            }
+        };
+    }
+
+    public function testGetCurrentChannelReturnsValueFromHandler(): void
+    {
+        $channel = Channel::factory()->create();
+        app()->bind(GetCurrentChannel::class, fn() => new class ($channel) {
+            public function __construct(private ?Channel $channel)
+            {
+            }
+
+            public function handle(): ?Channel
+            {
+                return $this->channel;
+            }
+        });
+
+        $this->assertTrue(
+            $channel->is($this->createTraitInstance()->getCurrentChannelPublic())
+        );
+    }
+
+    public function testGetCurrentChannelOnlyIfHaveAccessReturnsNullWhenNoChannel(): void
+    {
+        app()->bind(GetCurrentChannel::class, fn() => new class () {
+            public function handle(): ?Channel
+            {
+                return null;
+            }
+        });
+
+        $this->assertNull(
+            $this->createTraitInstance()->getCurrentChannelOnlyIfHaveAccessPublic()
+        );
+    }
+
+    public function testGetCurrentChannelOnlyIfHaveAccessReturnsNullWhenUserLacksAccess(): void
+    {
+        $channel = Channel::factory()->create();
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        Gate::define('page.channels.access_for_channel', fn(User $authUser, Channel $gateChannel) => false);
+
+        app()->bind(GetCurrentChannel::class, fn() => new class ($channel) {
+            public function __construct(private Channel $channel)
+            {
+            }
+
+            public function handle(): Channel
+            {
+                return $this->channel;
+            }
+        });
+
+        $this->assertNull(
+            $this->createTraitInstance()->getCurrentChannelOnlyIfHaveAccessPublic()
+        );
+    }
+
+    public function testGetCurrentChannelOnlyIfHaveAccessReturnsChannelForAuthorizedUser(): void
+    {
+        $channel = Channel::factory()->create();
+        $user = User::factory()
+            ->create();
+        $this->actingAs($user);
+
+        Gate::define('page.channels.access_for_channel', fn(User $authUser, Channel $gateChannel) =>
+            $authUser->is($user) && $gateChannel->is($channel)
+        );
+
+        app()->bind(GetCurrentChannel::class, fn() => new class ($channel) {
+            public function __construct(private Channel $channel)
+            {
+            }
+
+            public function handle(): Channel
+            {
+                return $this->channel;
+            }
+        });
+
+        $this->assertTrue(
+            $channel->is($this->createTraitInstance()->getCurrentChannelOnlyIfHaveAccessPublic())
+        );
+    }
+
+    public function testUserHasAccessToChannelRejectsNonChannelModels(): void
+    {
+        $traitClass = get_class($this->createTraitInstance());
+
+        $this->assertFalse($traitClass::userHasAccessToChannel(new class () extends Model {
+        }));
+    }
+
+    public function testUserHasAccessToChannelRequiresAuthenticatedUser(): void
+    {
+        $channel = Channel::factory()->create();
+        $traitClass = get_class($this->createTraitInstance());
+
+        $this->assertFalse($traitClass::userHasAccessToChannel($channel));
+    }
+
+    public function testUserHasAccessToChannelRespectsChannelAuthorization(): void
+    {
+        $channel = Channel::factory()->create();
+        $userWithoutAccess = User::factory()->create();
+        $authorizedUser = User::factory()->create();
+        $traitClass = get_class($this->createTraitInstance());
+
+        Gate::define('page.channels.access_for_channel', function (User $authUser, Channel $gateChannel) use ($authorizedUser, $channel) {
+            return $authUser->is($authorizedUser) && $gateChannel->is($channel);
+        });
+
+        $this->assertFalse($traitClass::userHasAccessToChannel($channel, $userWithoutAccess));
+        $this->assertTrue($traitClass::userHasAccessToChannel($channel, $authorizedUser));
+    }
+}

--- a/tests/Integration/Filament/Traits/HasChannelAuthorizationTraitTest.php
+++ b/tests/Integration/Filament/Traits/HasChannelAuthorizationTraitTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Filament\Traits;
+
+use App\Filament\Traits\HasChannelAuthorizationTrait;
+use App\Models\Channel;
+use App\Models\User;
+use Illuminate\Support\Facades\Gate;
+use Tests\DatabaseTestCase;
+
+final class HasChannelAuthorizationTraitTest extends DatabaseTestCase
+{
+    private function createTraitInstance(): object
+    {
+        return new class () {
+            use HasChannelAuthorizationTrait;
+        };
+    }
+
+    public function testCrudPermissionsDenyUnauthorizedUsers(): void
+    {
+        $channel = Channel::factory()->create();
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        Gate::define('page.channels.access_for_channel', fn(User $authUser, Channel $gateChannel) => false);
+
+        $traitClass = get_class($this->createTraitInstance());
+
+        foreach (['canEdit', 'canView', 'canDelete', 'canForceDelete', 'canRestore'] as $method) {
+            $this->assertFalse($traitClass::$method($channel));
+        }
+    }
+
+    public function testCrudPermissionsAllowAuthorizedUsers(): void
+    {
+        $channel = Channel::factory()->create();
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        Gate::define('page.channels.access_for_channel', fn(User $authUser, Channel $gateChannel) =>
+            $authUser->is($user) && $gateChannel->is($channel)
+        );
+
+        $traitClass = get_class($this->createTraitInstance());
+
+        foreach (['canEdit', 'canView', 'canDelete', 'canForceDelete', 'canRestore'] as $method) {
+            $this->assertTrue($traitClass::$method($channel));
+        }
+    }
+}

--- a/tests/Integration/Filament/Traits/UserAccessChannelTraitTest.php
+++ b/tests/Integration/Filament/Traits/UserAccessChannelTraitTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Filament\Traits;
+
+use App\Filament\Traits\UserAccessChannelTrait;
+use App\Models\Channel;
+use App\Models\User;
+use Illuminate\Support\Facades\Gate;
+use Tests\DatabaseTestCase;
+
+final class UserAccessChannelTraitTest extends DatabaseTestCase
+{
+    private function createTraitInstance(): object
+    {
+        return new class () {
+            use UserAccessChannelTrait {
+                userCanAccessChannelPage as public userCanAccessChannelPagePublic;
+            }
+        };
+    }
+
+    public function testInstanceMethodRequiresAuthenticatedUser(): void
+    {
+        $this->assertFalse($this->createTraitInstance()->userCanAccessChannelPagePublic());
+    }
+
+    public function testInstanceMethodDeniesUserWithoutRoleOrChannelAccess(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        Gate::define('page.channels.access', fn() => false);
+
+        $this->assertFalse($this->createTraitInstance()->userCanAccessChannelPagePublic());
+    }
+
+    public function testInstanceMethodAllowsUserWithChannelAccess(): void
+    {
+        $channel = Channel::factory()->create();
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        Gate::define('page.channels.access', fn(User $authUser) => $authUser->is($user));
+
+        $this->assertTrue($this->createTraitInstance()->userCanAccessChannelPagePublic());
+    }
+
+    public function testStaticMethodReturnsFalseWithoutUser(): void
+    {
+        $traitClass = get_class($this->createTraitInstance());
+
+        $this->assertFalse($traitClass::userCanAccessChannelPageStatic());
+    }
+
+    public function testStaticMethodUsesProvidedUser(): void
+    {
+        $channel = Channel::factory()->create();
+        $user = User::factory()->create();
+
+        $traitClass = get_class($this->createTraitInstance());
+
+        Gate::define('page.channels.access', fn(User $authUser) => $authUser->is($user));
+
+        $this->assertTrue($traitClass::userCanAccessChannelPageStatic($user));
+    }
+}


### PR DESCRIPTION
## Summary
- add integration coverage for ChannelOwnerContextTrait channel resolution and access checks
- cover HasChannelAuthorizationTrait CRUD authorization gates
- exercise UserAccessChannelTrait instance and static access helpers

## Testing
- php -d memory_limit=512M ./vendor/bin/phpunit --no-coverage tests/Integration/Filament/Traits


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952e7f7d56883299ed8443338bfc60a)