### PR TITLE
Add feature tests for channel workspace cluster

### DIFF
--- a/tests/Integration/Filament/Standard/Clusters/ChannelWorkspace/ChannelWorkspaceTest.php
+++ b/tests/Integration/Filament/Standard/Clusters/ChannelWorkspace/ChannelWorkspaceTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Filament\Standard\Clusters\ChannelWorkspace;
+
+use App\Filament\Standard\Clusters\ChannelWorkspace\ChannelWorkspace;
+use Tests\DatabaseTestCase;
+
+final class ChannelWorkspaceTest extends DatabaseTestCase
+{
+    public function testNavigationMetadataUsesTranslatedLabels(): void
+    {
+        $this->assertSame(
+            __('nav.channel_owner'),
+            ChannelWorkspace::getNavigationGroup(),
+        );
+
+        $this->assertSame(
+            __('channel-workspace.title'),
+            ChannelWorkspace::getNavigationLabel(),
+        );
+
+        $this->assertSame(
+            __('channel-workspace.title'),
+            ChannelWorkspace::getClusterBreadcrumb(),
+        );
+
+        $this->assertSame(
+            __('channel-workspace.title'),
+            (new ChannelWorkspace())->getTitle(),
+        );
+    }
+}

--- a/tests/Integration/Filament/Standard/Clusters/ChannelWorkspace/Pages/ChannelOAuthSettingsTest.php
+++ b/tests/Integration/Filament/Standard/Clusters/ChannelWorkspace/Pages/ChannelOAuthSettingsTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Filament\Standard\Clusters\ChannelWorkspace\Pages;
+
+use App\Enum\Guard\GuardEnum;
+use App\Enum\PanelEnum;
+use App\Enum\Users\RoleEnum;
+use App\Filament\Standard\Clusters\ChannelWorkspace\ChannelWorkspace;
+use App\Filament\Standard\Clusters\ChannelWorkspace\Pages\ChannelOAuthSettings;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Livewire\Livewire;
+use App\Repository\TeamRepository;
+use Tests\DatabaseTestCase;
+
+final class ChannelOAuthSettingsTest extends DatabaseTestCase
+{
+    public function testChannelOauthSettingsIsNotAccessible(): void
+    {
+        $user = User::factory()
+            ->withOwnTeam()
+            ->withRole(RoleEnum::CHANNEL_OPERATOR, GuardEnum::STANDARD->value)
+            ->create();
+
+        $tenant = app(TeamRepository::class)->getDefaultTeamForUser($user);
+
+        Filament::setCurrentPanel(PanelEnum::STANDARD->value);
+        Filament::setTenant($tenant, true);
+        Filament::auth()->login($user);
+        $this->actingAs($user, GuardEnum::STANDARD->value);
+
+        Livewire::test(ChannelOAuthSettings::class)
+            ->assertForbidden();
+    }
+
+    public function testClusterAndViewAreRegistered(): void
+    {
+        $this->assertSame(ChannelWorkspace::class, ChannelOAuthSettings::getCluster());
+        $this->assertSame(
+            'filament.standard.pages.channel-o-auth-settings',
+            (new ChannelOAuthSettings())->getView(),
+        );
+    }
+}

--- a/tests/Integration/Filament/Standard/Clusters/ChannelWorkspace/Resources/ChannelResource/Pages/EditChannelTest.php
+++ b/tests/Integration/Filament/Standard/Clusters/ChannelWorkspace/Resources/ChannelResource/Pages/EditChannelTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Filament\Standard\Clusters\ChannelWorkspace\Resources\ChannelResource\Pages;
+
+use App\Enum\Guard\GuardEnum;
+use App\Enum\PanelEnum;
+use App\Enum\Users\RoleEnum;
+use App\Auth\Abilities\AccessChannelPageAbility;
+use App\Auth\Abilities\Contracts\AbilityContract;
+use App\Filament\Standard\Clusters\ChannelWorkspace\Resources\ChannelResource\Pages\EditChannel;
+use App\Models\Channel;
+use App\Models\Team;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Livewire\Livewire;
+use App\Repository\TeamRepository;
+use Spatie\Permission\Models\Permission;
+use Tests\DatabaseTestCase;
+use Illuminate\Support\Facades\Gate;
+
+final class EditChannelTest extends DatabaseTestCase
+{
+    private User $user;
+
+    private Channel $channel;
+
+    private Team $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('filament-shield.enabled', false);
+        $this->allowChannelPolicies();
+
+        $this->channel = Channel::factory()->create([
+            'name' => 'My Channel',
+            'email' => 'creator@example.test',
+            'creator_name' => 'Creator Name',
+            'youtube_name' => 'creator',
+            'is_video_reception_paused' => false,
+        ]);
+
+        $this->allowChannelAccessAbility();
+        $this->allowChannelGate();
+        $this->user = User::factory()
+            ->withOwnTeam()
+            ->withRole(RoleEnum::CHANNEL_OPERATOR, GuardEnum::STANDARD->value)
+            ->haveAccessToChannel($this->channel)
+            ->create();
+
+        $this->grantChannelPermissions();
+
+        $this->tenant = app(TeamRepository::class)->getDefaultTeamForUser($this->user);
+
+        Filament::setCurrentPanel(PanelEnum::STANDARD->value);
+        Filament::setTenant($this->tenant, true);
+        Filament::auth()->login($this->user);
+        $this->actingAs($this->user, GuardEnum::STANDARD->value);
+        $this->actingAs($this->user);
+    }
+
+    public function testEditPageValidatesAndUpdatesChannel(): void
+    {
+        Livewire::test(EditChannel::class, ['record' => $this->channel->getKey()])
+            ->assertSuccessful()
+            ->assertActionVisible('view')
+            ->assertFormSet([
+                'name' => 'My Channel',
+                'creator_name' => 'Creator Name',
+                'email' => 'creator@example.test',
+                'youtube_name' => 'creator',
+                'is_video_reception_paused' => false,
+            ])
+            ->fillForm([
+                'name' => '',
+                'email' => '',
+            ])
+            ->call('save')
+            ->assertHasFormErrors([
+                'name' => 'required',
+                'email' => 'required',
+            ])
+            ->fillForm([
+                'name' => 'Updated Channel',
+                'email' => 'new@example.test',
+                'youtube_name' => 'new-handle',
+                'is_video_reception_paused' => true,
+            ])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $this->channel->refresh();
+
+        $this->assertSame('Updated Channel', $this->channel->getAttribute('name'));
+        $this->assertSame('new@example.test', $this->channel->getAttribute('email'));
+        $this->assertSame('new-handle', $this->channel->getAttribute('youtube_name'));
+        $this->assertTrue($this->channel->getAttribute('is_video_reception_paused'));
+    }
+
+    private function allowChannelAccessAbility(): void
+    {
+        $this->app->bind(AccessChannelPageAbility::class, static fn(): AbilityContract => new class () implements AbilityContract {
+            public function check(User $user): bool
+            {
+                return true;
+            }
+
+            public function checkForChannel(User $user, ?Channel $channel = null): bool
+            {
+                return true;
+            }
+        });
+    }
+
+    private function allowChannelGate(): void
+    {
+        Gate::after(static function (User $user, string $ability): ?bool {
+            if (in_array($ability, ['page.channels.access', 'page.channels.access_for_channel'], true)) {
+                return true;
+            }
+
+            return null;
+        });
+    }
+
+    private function allowChannelPolicies(): void
+    {
+        Gate::before(static function (User $user, string $ability, array $arguments = []): ?bool {
+            if (($arguments[0] ?? null) instanceof Channel || ($arguments[0] ?? null) === Channel::class) {
+                return true;
+            }
+
+            return null;
+        });
+    }
+
+    private function grantChannelPermissions(): void
+    {
+        $permissions = [
+            'ViewAny:Channel',
+            'View:Channel',
+            'Update:Channel',
+        ];
+
+        foreach ($permissions as $permission) {
+            Permission::findOrCreate($permission, GuardEnum::STANDARD->value);
+        }
+
+        $this->user->givePermissionTo($permissions);
+    }
+}

--- a/tests/Integration/Filament/Standard/Clusters/ChannelWorkspace/Resources/ChannelResource/Pages/ListChannelsTest.php
+++ b/tests/Integration/Filament/Standard/Clusters/ChannelWorkspace/Resources/ChannelResource/Pages/ListChannelsTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Filament\Standard\Clusters\ChannelWorkspace\Resources\ChannelResource\Pages;
+
+use App\Enum\Guard\GuardEnum;
+use App\Enum\PanelEnum;
+use App\Enum\Users\RoleEnum;
+use App\Auth\Abilities\AccessChannelPageAbility;
+use App\Auth\Abilities\Contracts\AbilityContract;
+use App\Filament\Standard\Clusters\ChannelWorkspace\Resources\ChannelResource\Pages\ListChannels;
+use App\Models\Channel;
+use App\Models\Team;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Livewire\Livewire;
+use App\Repository\TeamRepository;
+use Spatie\Permission\Models\Permission;
+use Tests\DatabaseTestCase;
+use Illuminate\Support\Facades\Gate;
+
+final class ListChannelsTest extends DatabaseTestCase
+{
+    private User $user;
+
+    private Channel $channel;
+
+    private Team $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('filament-shield.enabled', false);
+        $this->allowChannelPolicies();
+
+        $this->channel = Channel::factory()->create([
+            'youtube_name' => 'creator',
+            'is_video_reception_paused' => false,
+        ]);
+
+        $this->allowChannelAccessAbility();
+        $this->allowChannelGate();
+        $this->user = User::factory()
+            ->withOwnTeam()
+            ->withRole(RoleEnum::CHANNEL_OPERATOR, GuardEnum::STANDARD->value)
+            ->haveAccessToChannel($this->channel)
+            ->create();
+
+        $this->grantChannelPermissions();
+
+        $this->tenant = app(TeamRepository::class)->getDefaultTeamForUser($this->user);
+
+        Filament::setCurrentPanel(PanelEnum::STANDARD->value);
+        Filament::setTenant($this->tenant, true);
+        Filament::auth()->login($this->user);
+        $this->actingAs($this->user, GuardEnum::STANDARD->value);
+        $this->actingAs($this->user);
+    }
+
+    public function testTableShowsOnlyChannelsUserCanAccess(): void
+    {
+        $blocked = Channel::factory()->create([
+            'name' => 'Blocked Channel',
+            'youtube_name' => 'blocked',
+        ]);
+
+        Livewire::test(ListChannels::class)
+            ->assertSuccessful()
+            ->assertCanSeeTableRecords([$this->channel])
+            ->assertCanNotSeeTableRecords([$blocked])
+            ->assertSee('@creator');
+    }
+
+    private function allowChannelAccessAbility(): void
+    {
+        $this->app->bind(AccessChannelPageAbility::class, static fn(): AbilityContract => new class () implements AbilityContract {
+            public function check(User $user): bool
+            {
+                return true;
+            }
+
+            public function checkForChannel(User $user, ?Channel $channel = null): bool
+            {
+                return true;
+            }
+        });
+    }
+
+    private function allowChannelGate(): void
+    {
+        Gate::after(static function (User $user, string $ability): ?bool {
+            if (in_array($ability, ['page.channels.access', 'page.channels.access_for_channel'], true)) {
+                return true;
+            }
+
+            return null;
+        });
+    }
+
+    private function allowChannelPolicies(): void
+    {
+        Gate::before(static function (User $user, string $ability, array $arguments = []): ?bool {
+            if (($arguments[0] ?? null) instanceof Channel || ($arguments[0] ?? null) === Channel::class) {
+                return true;
+            }
+
+            return null;
+        });
+    }
+
+    private function grantChannelPermissions(): void
+    {
+        $permissions = [
+            'ViewAny:Channel',
+            'View:Channel',
+            'Update:Channel',
+        ];
+
+        foreach ($permissions as $permission) {
+            Permission::findOrCreate($permission, GuardEnum::STANDARD->value);
+        }
+
+        $this->user->givePermissionTo($permissions);
+    }
+}

--- a/tests/Integration/Filament/Standard/Clusters/ChannelWorkspace/Resources/ChannelResource/Pages/ViewChannelTest.php
+++ b/tests/Integration/Filament/Standard/Clusters/ChannelWorkspace/Resources/ChannelResource/Pages/ViewChannelTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Filament\Standard\Clusters\ChannelWorkspace\Resources\ChannelResource\Pages;
+
+use App\Enum\Guard\GuardEnum;
+use App\Enum\PanelEnum;
+use App\Enum\Users\RoleEnum;
+use App\Auth\Abilities\AccessChannelPageAbility;
+use App\Auth\Abilities\Contracts\AbilityContract;
+use App\Filament\Standard\Clusters\ChannelWorkspace\Resources\ChannelResource\Pages\ViewChannel;
+use App\Models\Channel;
+use App\Models\Team;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Livewire\Livewire;
+use App\Repository\TeamRepository;
+use Spatie\Permission\Models\Permission;
+use Tests\DatabaseTestCase;
+use Illuminate\Support\Facades\Gate;
+
+final class ViewChannelTest extends DatabaseTestCase
+{
+    private User $user;
+
+    private Channel $channel;
+
+    private Team $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('filament-shield.enabled', false);
+        $this->allowChannelPolicies();
+
+        $this->channel = Channel::factory()->create([
+            'name' => 'My Channel',
+            'email' => 'creator@example.test',
+            'youtube_name' => 'creator',
+            'is_video_reception_paused' => true,
+        ]);
+
+        $this->allowChannelAccessAbility();
+        $this->allowChannelGate();
+        $this->user = User::factory()
+            ->withOwnTeam()
+            ->withRole(RoleEnum::CHANNEL_OPERATOR, GuardEnum::STANDARD->value)
+            ->haveAccessToChannel($this->channel)
+            ->create();
+
+        $this->grantChannelPermissions();
+
+        $this->tenant = app(TeamRepository::class)->getDefaultTeamForUser($this->user);
+
+        Filament::setCurrentPanel(PanelEnum::STANDARD->value);
+        Filament::setTenant($this->tenant, true);
+        Filament::auth()->login($this->user);
+        $this->actingAs($this->user, GuardEnum::STANDARD->value);
+        $this->actingAs($this->user);
+    }
+
+    public function testViewPageRendersChannelDetails(): void
+    {
+        Livewire::test(ViewChannel::class, ['record' => $this->channel->getKey()])
+            ->assertSuccessful()
+            ->assertActionVisible('edit')
+            ->assertSee('My Channel')
+            ->assertSee('creator@example.test')
+            ->assertSee('@creator')
+            ->assertSee(__('common.is_video_reception_paused'));
+    }
+
+    private function allowChannelAccessAbility(): void
+    {
+        $this->app->bind(AccessChannelPageAbility::class, static fn(): AbilityContract => new class () implements AbilityContract {
+            public function check(User $user): bool
+            {
+                return true;
+            }
+
+            public function checkForChannel(User $user, ?Channel $channel = null): bool
+            {
+                return true;
+            }
+        });
+    }
+
+    private function allowChannelGate(): void
+    {
+        Gate::after(static function (User $user, string $ability): ?bool {
+            if (in_array($ability, ['page.channels.access', 'page.channels.access_for_channel'], true)) {
+                return true;
+            }
+
+            return null;
+        });
+    }
+
+    private function allowChannelPolicies(): void
+    {
+        Gate::before(static function (User $user, string $ability, array $arguments = []): ?bool {
+            if (($arguments[0] ?? null) instanceof Channel || ($arguments[0] ?? null) === Channel::class) {
+                return true;
+            }
+
+            return null;
+        });
+    }
+
+    private function grantChannelPermissions(): void
+    {
+        $permissions = [
+            'ViewAny:Channel',
+            'View:Channel',
+            'Update:Channel',
+        ];
+
+        foreach ($permissions as $permission) {
+            Permission::findOrCreate($permission, GuardEnum::STANDARD->value);
+        }
+
+        $this->user->givePermissionTo($permissions);
+    }
+}

--- a/tests/Integration/Filament/Standard/Clusters/ChannelWorkspace/Resources/ChannelResource/RelationManagers/UsersRelationManagerTest.php
+++ b/tests/Integration/Filament/Standard/Clusters/ChannelWorkspace/Resources/ChannelResource/RelationManagers/UsersRelationManagerTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Filament\Standard\Clusters\ChannelWorkspace\Resources\ChannelResource\RelationManagers;
+
+use App\Enum\Guard\GuardEnum;
+use App\Enum\PanelEnum;
+use App\Enum\Users\RoleEnum;
+use App\Auth\Abilities\AccessChannelPageAbility;
+use App\Auth\Abilities\Contracts\AbilityContract;
+use App\Filament\Standard\Clusters\ChannelWorkspace\Resources\ChannelResource\Pages\ViewChannel;
+use App\Filament\Standard\Clusters\ChannelWorkspace\Resources\ChannelResource\RelationManagers\UsersRelationManager;
+use App\Models\Channel;
+use App\Models\Team;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Livewire\Livewire;
+use App\Repository\TeamRepository;
+use Spatie\Permission\Models\Permission;
+use Tests\DatabaseTestCase;
+use Illuminate\Support\Facades\Gate;
+
+final class UsersRelationManagerTest extends DatabaseTestCase
+{
+    private User $user;
+
+    private Channel $channel;
+
+    private Team $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('filament-shield.enabled', false);
+
+        $this->channel = Channel::factory()->create();
+        $this->allowChannelAccessAbility();
+        $this->allowChannelGate();
+        $this->user = User::factory()
+            ->withOwnTeam()
+            ->withRole(RoleEnum::CHANNEL_OPERATOR, GuardEnum::STANDARD->value)
+            ->haveAccessToChannel($this->channel)
+            ->create();
+
+        $this->grantChannelPermissions();
+
+        $this->tenant = app(TeamRepository::class)->getDefaultTeamForUser($this->user);
+
+        Filament::setCurrentPanel(PanelEnum::STANDARD->value);
+        Filament::setTenant($this->tenant, true);
+        Filament::auth()->login($this->user);
+        $this->actingAs($this->user, GuardEnum::STANDARD->value);
+        $this->actingAs($this->user);
+    }
+
+    public function testUsersRelationManagerListsMembersAndHidesSelfRevokeAction(): void
+    {
+        $otherUser = User::factory()
+            ->withRole(RoleEnum::CHANNEL_OPERATOR, GuardEnum::STANDARD->value)
+            ->haveAccessToChannel($this->channel)
+            ->create();
+
+        Livewire::test(UsersRelationManager::class, [
+            'ownerRecord' => $this->channel,
+            'pageClass' => ViewChannel::class,
+        ])
+            ->assertSuccessful()
+            ->assertCanSeeTableRecords([$this->user, $otherUser])
+            ->assertTableActionHidden('revokeAccess', $this->user)
+            ->assertTableActionVisible('revokeAccess', $otherUser);
+    }
+
+    private function allowChannelAccessAbility(): void
+    {
+        $this->app->bind(AccessChannelPageAbility::class, static fn(): AbilityContract => new class () implements AbilityContract {
+            public function check(User $user): bool
+            {
+                return true;
+            }
+
+            public function checkForChannel(User $user, ?Channel $channel = null): bool
+            {
+                return true;
+            }
+        });
+    }
+
+    private function allowChannelGate(): void
+    {
+        Gate::after(static function (User $user, string $ability): ?bool {
+            if (in_array($ability, ['page.channels.access', 'page.channels.access_for_channel'], true)) {
+                return true;
+            }
+
+            return null;
+        });
+    }
+
+    private function grantChannelPermissions(): void
+    {
+        $permissions = [
+            'ViewAny:Channel',
+            'View:Channel',
+            'Update:Channel',
+        ];
+
+        foreach ($permissions as $permission) {
+            Permission::findOrCreate($permission, GuardEnum::STANDARD->value);
+        }
+
+        $this->user->givePermissionTo($permissions);
+    }
+}

--- a/tests/Integration/Filament/Standard/Clusters/ChannelWorkspace/Resources/ChannelResourceTest.php
+++ b/tests/Integration/Filament/Standard/Clusters/ChannelWorkspace/Resources/ChannelResourceTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Filament\Standard\Clusters\ChannelWorkspace\Resources;
+
+use App\Enum\Guard\GuardEnum;
+use App\Enum\PanelEnum;
+use App\Enum\Users\RoleEnum;
+use App\Auth\Abilities\AccessChannelPageAbility;
+use App\Auth\Abilities\Contracts\AbilityContract;
+use App\Filament\Standard\Clusters\ChannelWorkspace\Resources\ChannelResource;
+use App\Filament\Standard\Clusters\ChannelWorkspace\Resources\ChannelResource\RelationManagers\UsersRelationManager;
+use App\Models\Channel;
+use App\Models\Team;
+use App\Models\User;
+use Filament\Facades\Filament;
+use App\Repository\TeamRepository;
+use Tests\DatabaseTestCase;
+
+final class ChannelResourceTest extends DatabaseTestCase
+{
+    private User $user;
+
+    private Channel $channel;
+
+    private Team $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->channel = Channel::factory()->create();
+        $this->allowChannelAccessAbility();
+        $this->user = User::factory()
+            ->withOwnTeam()
+            ->withRole(RoleEnum::CHANNEL_OPERATOR, GuardEnum::STANDARD->value)
+            ->haveAccessToChannel($this->channel)
+            ->create();
+
+        $this->tenant = app(TeamRepository::class)->getDefaultTeamForUser($this->user);
+
+        Filament::setCurrentPanel(PanelEnum::STANDARD->value);
+        Filament::setTenant($this->tenant, true);
+        Filament::auth()->login($this->user);
+        $this->actingAs($this->user, GuardEnum::STANDARD->value);
+    }
+
+    public function testChannelsAreScopedToAuthenticatedUser(): void
+    {
+        $otherChannel = Channel::factory()->create();
+
+        $ids = ChannelResource::getEloquentQuery()->pluck('id')->all();
+
+        $this->assertContains($this->channel->getKey(), $ids);
+        $this->assertNotContains($otherChannel->getKey(), $ids);
+    }
+
+    public function testMetadataAndRelationsAreRegistered(): void
+    {
+        $this->assertFalse(ChannelResource::canCreate());
+        $this->assertContains(
+            UsersRelationManager::class,
+            ChannelResource::getRelations(),
+        );
+
+        $pages = ChannelResource::getPages();
+
+        $this->assertArrayHasKey('index', $pages);
+        $this->assertArrayHasKey('view', $pages);
+        $this->assertArrayHasKey('edit', $pages);
+    }
+
+    private function allowChannelAccessAbility(): void
+    {
+        $this->app->bind(AccessChannelPageAbility::class, static fn(): AbilityContract => new class () implements AbilityContract {
+            public function check(User $user): bool
+            {
+                return true;
+            }
+
+            public function checkForChannel(User $user, ?Channel $channel = null): bool
+            {
+                return true;
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add coverage for the Channel Workspace cluster, OAuth page, resource pages, and relation manager
- ensure channel access, permissions, and Filament tenancy contexts are stubbed for tests
- validate resource forms, tables, and actions for channel operators

## Testing
- php -d memory_limit=512M ./vendor/bin/phpunit --no-coverage tests/Integration/Filament/Standard/Clusters
- composer install --no-interaction
- php -d memory_limit=512M ./vendor/bin/phpunit --no-coverage

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952faa34be483298a169a0bedf184b7)